### PR TITLE
feature: allow filters as query parameters on Gamma API - list series

### DIFF
--- a/src/Resources/Gamma/Series.php
+++ b/src/Resources/Gamma/Series.php
@@ -12,13 +12,16 @@ class Series extends Resource
     /**
      * List series.
      *
+     * @param array<string, mixed> $filters
      * @return array<int, array<string, mixed>>
      *
      * @throws PolymarketException
      */
-    public function list(): array
+    public function list(array $filters = []): array
     {
-        $response = $this->httpClient->get('/series');
+        $response = $this->httpClient->get('/series', [
+            ...$filters,
+        ]);
 
         /** @var array<int, array<string, mixed>> */
         return $response->json();

--- a/tests/Feature/Gamma/SeriesTest.php
+++ b/tests/Feature/Gamma/SeriesTest.php
@@ -34,6 +34,22 @@ describe('Series::list()', function (): void {
             ->and($result[0]['title'])->toBe('NBA Finals 2024');
     });
 
+    it('applies custom filters', function (): void {
+        $seriesData = $this->loadFixture('series_list.json');
+        $filteredData = array_filter($seriesData, fn ($s): bool => 'abc' === $s['slug']);
+
+        $this->fakeHttp->addJsonResponse('GET', '/series', array_values($filteredData));
+
+        $result = $this->client->gamma()->series()->list(filters: ['slug' => 'abc']);
+
+        expect($result)->toBeArray()
+            ->and(count($result))->toBe(1);
+
+        foreach ($result as $market) {
+            expect($market['slug'])->toBe('abc');
+        }
+    });
+
     it('handles empty series list', function (): void {
         $this->fakeHttp->addJsonResponse('GET', '/series', []);
 

--- a/tests/Fixtures/series_list.json
+++ b/tests/Fixtures/series_list.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "1234",
+    "title": "Abc",
+    "slug": "abc"
+  },
+  {
+    "id": "5678",
+    "title": "Def",
+    "slug": "def"
+  },
+  {
+    "id": "9012",
+    "title": "Ghi",
+    "slug": "ghi"
+  }
+]


### PR DESCRIPTION
As per the official documentation, the listSeries endpoint can accept query parameters as filters: https://docs.polymarket.com/api-reference/series/list-series