### PR TITLE
feat(signing): migrate order signing to CLOB V2/V3

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,14 +436,15 @@ OrderStatus::UNMATCHED  // Marketable but experiencing delay
 
 #### SignatureType
 
-For order authentication methods:
+For order authentication methods (canonical CLOB V2 values):
 
 ```php
 use PolymarketPhp\Polymarket\Enums\SignatureType;
 
-SignatureType::POLYMARKET_PROXY_EMAIL   // Email/Magic account (value: 1)
-SignatureType::POLYMARKET_PROXY_WALLET  // Browser wallet (value: 2)
-SignatureType::EOA                      // Externally owned account (value: 0)
+SignatureType::EOA               // Externally owned account (value: 0)
+SignatureType::POLY_PROXY        // Polymarket proxy wallet (value: 1)
+SignatureType::POLY_GNOSIS_SAFE  // Polymarket Gnosis Safe (value: 2)
+SignatureType::POLY_1271         // EIP-1271 smart contract wallet (value: 3, signing not supported yet)
 ```
 
 ### Usage Example

--- a/docs/superpowers/specs/2026-07-11-clob-v2-order-signing-design.md
+++ b/docs/superpowers/specs/2026-07-11-clob-v2-order-signing-design.md
@@ -1,0 +1,106 @@
+# CLOB V2 Order Signing Migration — Design
+
+Date: 2026-07-11
+Branch: `feat/clob-v2-migration` (based on `pr/27`)
+
+## Problem
+
+Polymarket cut production over to CLOB V2 on 2026-04-28. V1-signed orders are
+rejected. This SDK still signs the V1 order struct (`taker`, `expiration`,
+`nonce`, `feeRateBps`) against the legacy exchange contract with EIP-712 domain
+version `"1"`, so `Orders::post()` cannot place orders on production.
+
+All facts below are verified against the official `Polymarket/py-clob-client-v2`
+and `Polymarket/clob-client-v2` sources and https://docs.polymarket.com/changelog.
+
+## V2/V3 facts (authoritative)
+
+EIP-712 Order struct (identical for order versions 2 and 3):
+
+```
+salt uint256, maker address, signer address, tokenId uint256,
+makerAmount uint256, takerAmount uint256, side uint8, signatureType uint8,
+timestamp uint256, metadata bytes32, builder bytes32
+```
+
+Domain: name `Polymarket CTF Exchange`, version `"2"` or `"3"` (matches order
+version), chainId, verifyingContract.
+
+Contracts (same on Polygon 137 and Amoy 80002 unless noted):
+
+| Contract | Address |
+|---|---|
+| Exchange V2 | `0xE111180000d2663C0091e4f400237545B87B996B` |
+| NegRisk Exchange V2 | `0xe2222d279d744050d28e00520010520000310F59` |
+| Exchange V3 (137) | `0xe3333700cA9d93003F00f0F71f8515005F6c00Aa` |
+| Exchange V3 (80002) | `0x9fE6e61422AdB6F610d8597F9684b16912D50C3D` |
+
+Selection: version 2 → negRisk ? NegRiskExchangeV2 : ExchangeV2.
+Version 3 → ExchangeV3 (no neg-risk split). The active version is served by
+`GET /version` on the CLOB API (official client defaults to 2 when absent).
+
+Defaults (from the official builder): `timestamp` = now in **milliseconds**;
+`metadata`/`builder` = 32 zero bytes; `expiration` = `"0"` — expiration is
+**not signed**, it only appears in the JSON payload.
+
+Signature types: `EOA=0`, `POLY_PROXY=1`, `POLY_GNOSIS_SAFE=2`, `POLY_1271=3`.
+POLY_1271 uses a nested Solady `TypedDataSign` flow — out of scope; we throw a
+clear `SigningException` for it.
+
+Wire format for `POST /order`:
+
+```json
+{
+  "order": {
+    "salt": <int>, "maker": "0x..", "signer": "0x..", "tokenId": "..",
+    "makerAmount": "..", "takerAmount": "..", "side": "BUY"|"SELL",
+    "expiration": "0", "signatureType": <int>, "timestamp": "..",
+    "metadata": "0x0..0", "builder": "0x0..0", "signature": "0x.."
+  },
+  "owner": "<apiKey>", "orderType": "GTC", "deferExec": false, "postOnly": false
+}
+```
+
+ClobAuth (L1) stays at domain version `"1"` — the auth path is untouched.
+
+## Design
+
+Follow the existing `TypedDataInterface` pattern; keep V1 for reference,
+make V2 the default path.
+
+1. **`Signing/TypedData/OrderPayloadV2`** — new class implementing
+   `TypedDataInterface`. Constructor:
+   `(array $orderData, int $chainId = 137, bool $negRisk = false, int $version = 2, ?string $verifyingContract = null)`.
+   Holds the V2/V3 contract constants, auto-selects the verifying contract,
+   domain version = `(string) $version`. Rejects unsupported versions.
+2. **`Enums/SignatureType`** — rename cases to canonical `EOA=0`,
+   `POLY_PROXY=1`, `POLY_GNOSIS_SAFE=2`, add `POLY_1271=3`. (Breaking rename;
+   pre-1.0 package, acceptable. Old names never shipped in a signing path.)
+3. **`Orders::post()`** — build and sign the V2 struct: fill defaults
+   (`salt` random, `timestamp` now-ms, `metadata`/`builder` zero-bytes32),
+   sign via `Eip712Signer` with `OrderPayloadV2`, then POST the V2 wire
+   format. New options: `negRisk` (default false), `postOnly` (default false),
+   `version` (default 2). Throw `SigningException` for `signatureType=3`.
+   `expiration` passes through to JSON only (default `"0"`).
+4. **`Server::version()`** — thin `GET /version` so callers can resolve the
+   active order version; SDK does not auto-resolve per-call (no hidden HTTP).
+5. **`OrderPayload` (V1)** — deprecated docblock; unchanged otherwise.
+
+## Testing
+
+- Unit `OrderPayloadV2Test`: struct/domain shape, contract auto-selection
+  matrix (chain × negRisk × version), invalid version.
+- Golden-value test: sign the official fixture (Hardhat dev key
+  `0xac0974…ff80`, salt `479249096354`, timestamp `1780449126930`, Amoy,
+  tokenId 1234, amounts 100000000/50000000, BUY, EOA) and assert the exact
+  signature produced by the reference `eth-account` implementation.
+- Feature `OrdersPostTest` (V2): wire-format assertions — no `nonce`/
+  `feeRateBps`/`taker` in payload, `postOnly`/`deferExec` present, side as
+  string, salt as int.
+- Existing V1 unit tests stay (class remains).
+
+## Out of scope
+
+POLY_1271 signing, batch `POST /orders` refactor (`create()`/`postMultiple()`
+double-binding — separate fix), Gamma keyset pagination, Bridge withdrawals,
+builder fee resolution endpoints, WebSocket/RTDS.

--- a/src/Auth/ClobAuthenticator.php
+++ b/src/Auth/ClobAuthenticator.php
@@ -6,9 +6,10 @@ namespace PolymarketPhp\Polymarket\Auth;
 
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\GuzzleException;
-use PolymarketPhp\Polymarket\Auth\Signer\Eip712Signer;
 use PolymarketPhp\Polymarket\Auth\Signer\HmacSigner;
 use PolymarketPhp\Polymarket\Exceptions\ClobAuthenticationException;
+use PolymarketPhp\Polymarket\Signing\Eip712Signer;
+use PolymarketPhp\Polymarket\Signing\TypedData\ClobAuthPayload;
 
 /**
  * Manages CLOB authentication flow (L1 and L2).
@@ -111,7 +112,7 @@ class ClobAuthenticator
     public function generateL1Headers(int $nonce = 0, ?int $timestamp = null): array
     {
         $timestamp ??= time();
-        $signature = $this->signer->signClobAuth($timestamp, $nonce);
+        $signature = $this->signer->sign(new ClobAuthPayload($this->signer->getAddress(), $timestamp, $nonce));
 
         return [
             'POLY_ADDRESS' => strtolower($this->signer->getAddress()),

--- a/src/Auth/ClobAuthenticator.php
+++ b/src/Auth/ClobAuthenticator.php
@@ -112,7 +112,9 @@ class ClobAuthenticator
     public function generateL1Headers(int $nonce = 0, ?int $timestamp = null): array
     {
         $timestamp ??= time();
-        $signature = $this->signer->sign(new ClobAuthPayload($this->signer->getAddress(), $timestamp, $nonce));
+        $signature = $this->signer->sign(
+            new ClobAuthPayload($this->signer->getAddress(), $timestamp, $nonce, $this->chainId)
+        );
 
         return [
             'POLY_ADDRESS' => strtolower($this->signer->getAddress()),

--- a/src/Auth/ClobAuthenticator.php
+++ b/src/Auth/ClobAuthenticator.php
@@ -177,6 +177,14 @@ class ClobAuthenticator
     }
 
     /**
+     * Expose the underlying signer so resources can sign payloads directly.
+     */
+    public function getSigner(): Eip712Signer
+    {
+        return $this->signer;
+    }
+
+    /**
      * Create a new instance with credentials (for immutability).
      */
     public function withCredentials(ApiCredentials $credentials): self

--- a/src/Client.php
+++ b/src/Client.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace PolymarketPhp\Polymarket;
 
 use PolymarketPhp\Polymarket\Auth\ClobAuthenticator;
-use PolymarketPhp\Polymarket\Auth\Signer\Eip712Signer;
 use PolymarketPhp\Polymarket\Exceptions\ClobAuthenticationException;
 use PolymarketPhp\Polymarket\Exceptions\SigningException;
 use PolymarketPhp\Polymarket\Http\AsyncClient;
 use PolymarketPhp\Polymarket\Http\AsyncClientInterface;
 use PolymarketPhp\Polymarket\Http\GuzzleHttpClient;
 use PolymarketPhp\Polymarket\Http\HttpClientInterface;
+use PolymarketPhp\Polymarket\Signing\Eip712Signer;
 
 class Client
 {

--- a/src/Clob.php
+++ b/src/Clob.php
@@ -76,7 +76,7 @@ class Clob
 
     public function orders(): Orders
     {
-        return new Orders($this->httpClient, $this->asyncClient);
+        return new Orders($this->config, $this->httpClient, $this->asyncClient);
     }
 
     public function pricing(): Pricing

--- a/src/Clob.php
+++ b/src/Clob.php
@@ -76,7 +76,7 @@ class Clob
 
     public function orders(): Orders
     {
-        return new Orders($this->config, $this->httpClient, $this->asyncClient);
+        return new Orders($this->authenticator?->getSigner(), $this->httpClient, $this->asyncClient);
     }
 
     public function pricing(): Pricing

--- a/src/Enums/OrderSide.php
+++ b/src/Enums/OrderSide.php
@@ -5,23 +5,24 @@ declare(strict_types=1);
 namespace PolymarketPhp\Polymarket\Enums;
 
 /**
- * Order side - whether buying or selling shares.
+ * Order side — whether buying or selling shares.
+ *
+ * `forSignature()` returns the integer representation required by the
+ * EIP-712 Order struct. For the CLOB API string representation use `->value`.
  */
 enum OrderSide: string
 {
     case BUY = 'BUY';
     case SELL = 'SELL';
 
+    /**
+     * Integer representation used in the EIP-712 Order struct.
+     */
     public function forSignature(): int
     {
         return match ($this) {
-            self::BUY => 0,
+            self::BUY  => 0,
             self::SELL => 1,
         };
-    }
-
-    public function forApi(): string
-    {
-        return $this->value;
     }
 }

--- a/src/Enums/OrderSide.php
+++ b/src/Enums/OrderSide.php
@@ -11,4 +11,17 @@ enum OrderSide: string
 {
     case BUY = 'BUY';
     case SELL = 'SELL';
+
+    public function forSignature(): int
+    {
+        return match ($this) {
+            self::BUY => 0,
+            self::SELL => 1,
+        };
+    }
+
+    public function forApi(): string
+    {
+        return $this->value;
+    }
 }

--- a/src/Enums/SignatureType.php
+++ b/src/Enums/SignatureType.php
@@ -5,11 +5,19 @@ declare(strict_types=1);
 namespace PolymarketPhp\Polymarket\Enums;
 
 /**
- * Signature type for order authentication.
+ * Signature type for order authentication (CLOB V2 canonical values).
  */
 enum SignatureType: int
 {
-    case POLYMARKET_PROXY_EMAIL = 1;
-    case POLYMARKET_PROXY_WALLET = 2;
+    /** ECDSA EIP-712 signature signed by an EOA. */
     case EOA = 0;
+
+    /** EIP-712 signature signed by the EOA owning a Polymarket proxy wallet. */
+    case POLY_PROXY = 1;
+
+    /** EIP-712 signature signed by the EOA owning a Polymarket Gnosis Safe. */
+    case POLY_GNOSIS_SAFE = 2;
+
+    /** EIP-1271 signature from a smart contract wallet (not supported for signing yet). */
+    case POLY_1271 = 3;
 }

--- a/src/Http/FakeGuzzleHttpClient.php
+++ b/src/Http/FakeGuzzleHttpClient.php
@@ -99,6 +99,19 @@ class FakeGuzzleHttpClient implements HttpClientInterface
         return isset($this->requests[$key]);
     }
 
+    /**
+     * Return the recorded request data for the given method and path, or null
+     * if no such request has been made yet.
+     *
+     * @return array{method: string, path: string, data: array<int|string, mixed>}|null
+     */
+    public function getRequest(string $method, string $path): ?array
+    {
+        $key = $this->makeKey($method, $path);
+
+        return $this->requests[$key] ?? null;
+    }
+
     public function addExceptionResponse(string $method, string $path, PolymarketException $exception): void
     {
         $key = $this->makeKey($method, $path);

--- a/src/Resources/Clob/Orders.php
+++ b/src/Resources/Clob/Orders.php
@@ -5,15 +5,29 @@ declare(strict_types=1);
 namespace PolymarketPhp\Polymarket\Resources\Clob;
 
 use GuzzleHttp\Promise\PromiseInterface;
+use PolymarketPhp\Polymarket\Config;
+use PolymarketPhp\Polymarket\Enums\OrderSide;
 use PolymarketPhp\Polymarket\Exceptions\PolymarketException;
+use PolymarketPhp\Polymarket\Http\AsyncClientInterface;
 use PolymarketPhp\Polymarket\Http\BatchResult;
+use PolymarketPhp\Polymarket\Http\HttpClientInterface;
 use PolymarketPhp\Polymarket\Http\Response;
 use PolymarketPhp\Polymarket\Resources\Resource;
 use PolymarketPhp\Polymarket\Resources\Traits\HasAsyncClient;
+use PolymarketPhp\Polymarket\Signing\Eip712Signer;
+use PolymarketPhp\Polymarket\Signing\TypedData\OrderPayload;
 
 class Orders extends Resource
 {
     use HasAsyncClient;
+
+    public function __construct(
+        private Config $config,
+        HttpClientInterface $httpClient,
+        ?AsyncClientInterface $asyncClient = null,
+    ) {
+        parent::__construct($httpClient, $asyncClient);
+    }
 
     /**
      * @param array<string, mixed> $filters
@@ -73,9 +87,37 @@ class Orders extends Resource
      *
      * @throws PolymarketException
      */
-    public function post(array $orderData): array
+    public function post(array $inputOrderData): array
     {
-        return $this->httpClient->post('/order', $orderData)->json();
+        $orderData = $inputOrderData['order'];
+
+        /** @var OrderSide $side */
+        $side = $orderData['side'];
+
+        // Adapt some fields to adhere to Ethereum data types
+        $orderData['side'] = $side->forSignature();
+
+        $key = $this->config->privateKey ?? throw new PolymarketException('Private key not set');
+        $signer = new Eip712Signer($key, $this->config->chainId);
+        $signature = $signer->sign(new OrderPayload($orderData));
+
+        $orderData['signature'] = $signature;
+
+        // Adapt some fields to adhere to Polymarket data types
+        $orderData['side'] = $side->forApi();
+        $orderData['feeRateBps'] = (string) $orderData['feeRateBps'];
+        $orderData['expiration'] = (string) $orderData['expiration'];
+        $orderData['nonce'] = (string) $orderData['nonce'];
+
+        $finalPayload = [
+            'order' => $orderData,
+            'owner' => $inputOrderData['owner'],
+            'orderType' =>$inputOrderData['orderType'],
+            'deferExec' => $inputOrderData['deferExec'] ?? false,
+        ];
+
+        return $this->httpClient->post('/order', $finalPayload)->json();
+
     }
 
     /**

--- a/src/Resources/Clob/Orders.php
+++ b/src/Resources/Clob/Orders.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PolymarketPhp\Polymarket\Resources\Clob;
 
 use GuzzleHttp\Promise\PromiseInterface;
-use PolymarketPhp\Polymarket\Config;
 use PolymarketPhp\Polymarket\Enums\OrderSide;
 use PolymarketPhp\Polymarket\Exceptions\PolymarketException;
 use PolymarketPhp\Polymarket\Http\AsyncClientInterface;
@@ -22,7 +21,7 @@ class Orders extends Resource
     use HasAsyncClient;
 
     public function __construct(
-        private Config $config,
+        private readonly ?Eip712Signer $signer,
         HttpClientInterface $httpClient,
         ?AsyncClientInterface $asyncClient = null,
     ) {
@@ -81,7 +80,13 @@ class Orders extends Resource
     }
 
     /**
-     * @param array<string, mixed> $orderData
+     * Build, sign, and submit a single order to the CLOB.
+     *
+     * The `order` sub-array must carry all twelve EIP-712 struct fields.
+     * Numeric fields (tokenId, amounts, expiration, nonce, feeRateBps, salt)
+     * may be passed as int or numeric string — both are handled transparently.
+     *
+     * @param array{order: array{maker: string, signer: string, taker: string, tokenId: string|int, makerAmount: string|int, takerAmount: string|int, expiration: int, nonce: int, feeRateBps: string|int, side: OrderSide, signatureType: int, salt: int}, owner: string, orderType: string, deferExec?: bool} $inputOrderData
      *
      * @return array<string, mixed>
      *
@@ -89,35 +94,38 @@ class Orders extends Resource
      */
     public function post(array $inputOrderData): array
     {
-        $orderData = $inputOrderData['order'];
+        $signer = $this->signer
+            ?? throw new PolymarketException(
+                'Signing requires authentication. Call Client::auth() before placing orders.'
+            );
 
-        /** @var OrderSide $side */
+        $orderData = $inputOrderData['order'];
         $side = $orderData['side'];
 
-        // Adapt some fields to adhere to Ethereum data types
+        // Convert the side enum to its integer representation for EIP-712 encoding
         $orderData['side'] = $side->forSignature();
 
-        $key = $this->config->privateKey ?? throw new PolymarketException('Private key not set');
-        $signer = new Eip712Signer($key, $this->config->chainId);
-        $signature = $signer->sign(new OrderPayload($orderData));
+        $orderData['signature'] = $signer->sign(
+            new OrderPayload($orderData, $signer->getChainId())
+        );
 
-        $orderData['signature'] = $signature;
-
-        // Adapt some fields to adhere to Polymarket data types
-        $orderData['side'] = $side->forApi();
-        $orderData['feeRateBps'] = (string) $orderData['feeRateBps'];
+        // Restore the string side value and normalise all numeric fields to
+        // strings, as required by the CLOB API.
+        $orderData['side'] = $side->value;
+        $orderData['salt'] = (string) $orderData['salt'];
+        $orderData['tokenId'] = (string) $orderData['tokenId'];
+        $orderData['makerAmount'] = (string) $orderData['makerAmount'];
+        $orderData['takerAmount'] = (string) $orderData['takerAmount'];
         $orderData['expiration'] = (string) $orderData['expiration'];
         $orderData['nonce'] = (string) $orderData['nonce'];
+        $orderData['feeRateBps'] = (string) $orderData['feeRateBps'];
 
-        $finalPayload = [
-            'order' => $orderData,
-            'owner' => $inputOrderData['owner'],
-            'orderType' =>$inputOrderData['orderType'],
+        return $this->httpClient->post('/order', [
+            'order'     => $orderData,
+            'owner'     => $inputOrderData['owner'],
+            'orderType' => $inputOrderData['orderType'],
             'deferExec' => $inputOrderData['deferExec'] ?? false,
-        ];
-
-        return $this->httpClient->post('/order', $finalPayload)->json();
-
+        ])->json();
     }
 
     /**

--- a/src/Resources/Clob/Orders.php
+++ b/src/Resources/Clob/Orders.php
@@ -6,7 +6,9 @@ namespace PolymarketPhp\Polymarket\Resources\Clob;
 
 use GuzzleHttp\Promise\PromiseInterface;
 use PolymarketPhp\Polymarket\Enums\OrderSide;
+use PolymarketPhp\Polymarket\Enums\SignatureType;
 use PolymarketPhp\Polymarket\Exceptions\PolymarketException;
+use PolymarketPhp\Polymarket\Exceptions\SigningException;
 use PolymarketPhp\Polymarket\Http\AsyncClientInterface;
 use PolymarketPhp\Polymarket\Http\BatchResult;
 use PolymarketPhp\Polymarket\Http\HttpClientInterface;
@@ -14,7 +16,7 @@ use PolymarketPhp\Polymarket\Http\Response;
 use PolymarketPhp\Polymarket\Resources\Resource;
 use PolymarketPhp\Polymarket\Resources\Traits\HasAsyncClient;
 use PolymarketPhp\Polymarket\Signing\Eip712Signer;
-use PolymarketPhp\Polymarket\Signing\TypedData\OrderPayload;
+use PolymarketPhp\Polymarket\Signing\TypedData\OrderPayloadV2;
 
 class Orders extends Resource
 {
@@ -80,13 +82,16 @@ class Orders extends Resource
     }
 
     /**
-     * Build, sign, and submit a single order to the CLOB.
+     * Build, sign, and submit a single CLOB V2 order.
      *
-     * The `order` sub-array must carry all twelve EIP-712 struct fields.
-     * Numeric fields (tokenId, amounts, expiration, nonce, feeRateBps, salt)
-     * may be passed as int or numeric string — both are handled transparently.
+     * The `order` sub-array carries the V2 EIP-712 struct fields; `salt`,
+     * `timestamp` (milliseconds), `metadata`, and `builder` are filled with
+     * defaults when omitted. `expiration` is no longer part of the signed
+     * struct — it is forwarded to the API only (default "0"). `negRisk`
+     * selects the neg-risk exchange contract and `version` (2 or 3) the
+     * exchange generation; neither is sent to the API.
      *
-     * @param array{order: array{maker: string, signer: string, taker: string, tokenId: string|int, makerAmount: string|int, takerAmount: string|int, expiration: int, nonce: int, feeRateBps: string|int, side: OrderSide, signatureType: int, salt: int}, owner: string, orderType: string, deferExec?: bool} $inputOrderData
+     * @param array{order: array{maker: string, signer: string, tokenId: string|int, makerAmount: string|int, takerAmount: string|int, side: OrderSide, signatureType?: int, salt?: int|string, timestamp?: string|int, metadata?: string, builder?: string, expiration?: string|int}, owner: string, orderType: string, deferExec?: bool, postOnly?: bool, negRisk?: bool, version?: int} $inputOrderData
      *
      * @return array<string, mixed>
      *
@@ -101,30 +106,55 @@ class Orders extends Resource
 
         $orderData = $inputOrderData['order'];
         $side = $orderData['side'];
+        $signatureType = $orderData['signatureType'] ?? SignatureType::EOA->value;
 
-        // Convert the side enum to its integer representation for EIP-712 encoding
-        $orderData['side'] = $side->forSignature();
+        if ($signatureType === SignatureType::POLY_1271->value) {
+            throw new SigningException(
+                'POLY_1271 orders require the nested TypedDataSign flow, which is not supported yet.'
+            );
+        }
 
-        $orderData['signature'] = $signer->sign(
-            new OrderPayload($orderData, $signer->getChainId())
-        );
+        $message = [
+            'salt'          => $orderData['salt'] ?? random_int(1, time() * 1000),
+            'maker'         => $orderData['maker'],
+            'signer'        => $orderData['signer'],
+            'tokenId'       => $orderData['tokenId'],
+            'makerAmount'   => $orderData['makerAmount'],
+            'takerAmount'   => $orderData['takerAmount'],
+            'side'          => $side->forSignature(),
+            'signatureType' => $signatureType,
+            'timestamp'     => (string) ($orderData['timestamp'] ?? (int) (microtime(true) * 1000)),
+            'metadata'      => $orderData['metadata'] ?? OrderPayloadV2::BYTES32_ZERO,
+            'builder'       => $orderData['builder'] ?? OrderPayloadV2::BYTES32_ZERO,
+        ];
 
-        // Restore the string side value and normalise all numeric fields to
-        // strings, as required by the CLOB API.
-        $orderData['side'] = $side->value;
-        $orderData['salt'] = (string) $orderData['salt'];
-        $orderData['tokenId'] = (string) $orderData['tokenId'];
-        $orderData['makerAmount'] = (string) $orderData['makerAmount'];
-        $orderData['takerAmount'] = (string) $orderData['takerAmount'];
-        $orderData['expiration'] = (string) $orderData['expiration'];
-        $orderData['nonce'] = (string) $orderData['nonce'];
-        $orderData['feeRateBps'] = (string) $orderData['feeRateBps'];
+        $signature = $signer->sign(new OrderPayloadV2(
+            $message,
+            $signer->getChainId(),
+            $inputOrderData['negRisk'] ?? false,
+            $inputOrderData['version'] ?? 2,
+        ));
 
         return $this->httpClient->post('/order', [
-            'order'     => $orderData,
+            'order' => [
+                'salt'          => (int) $message['salt'],
+                'maker'         => $message['maker'],
+                'signer'        => $message['signer'],
+                'tokenId'       => (string) $message['tokenId'],
+                'makerAmount'   => (string) $message['makerAmount'],
+                'takerAmount'   => (string) $message['takerAmount'],
+                'side'          => $side->value,
+                'expiration'    => (string) ($orderData['expiration'] ?? '0'),
+                'signatureType' => $signatureType,
+                'timestamp'     => $message['timestamp'],
+                'metadata'      => $message['metadata'],
+                'builder'       => $message['builder'],
+                'signature'     => $signature,
+            ],
             'owner'     => $inputOrderData['owner'],
             'orderType' => $inputOrderData['orderType'],
             'deferExec' => $inputOrderData['deferExec'] ?? false,
+            'postOnly'  => $inputOrderData['postOnly'] ?? false,
         ])->json();
     }
 

--- a/src/Resources/Clob/Server.php
+++ b/src/Resources/Clob/Server.php
@@ -10,23 +10,23 @@ use PolymarketPhp\Polymarket\Resources\Resource;
 class Server extends Resource
 {
     /**
-     * @return array<string, mixed>
+     * @return string
      *
      * @throws PolymarketException
      */
-    public function healthCheck(): array
+    public function healthCheck(): string
     {
-        return $this->httpClient->get('/')->json();
+        return $this->httpClient->get('/')->body();
     }
 
     /**
-     * @return array<string, mixed>
+     * @return int
      *
      * @throws PolymarketException
      */
-    public function getTime(): array
+    public function getTime(): int
     {
-        return $this->httpClient->get('/time')->json();
+        return (int) $this->httpClient->get('/time')->body();
     }
 
     /**

--- a/src/Resources/Clob/Server.php
+++ b/src/Resources/Clob/Server.php
@@ -10,8 +10,6 @@ use PolymarketPhp\Polymarket\Resources\Resource;
 class Server extends Resource
 {
     /**
-     * @return string
-     *
      * @throws PolymarketException
      */
     public function healthCheck(): string
@@ -20,8 +18,6 @@ class Server extends Resource
     }
 
     /**
-     * @return int
-     *
      * @throws PolymarketException
      */
     public function getTime(): int

--- a/src/Resources/Clob/Server.php
+++ b/src/Resources/Clob/Server.php
@@ -26,6 +26,19 @@ class Server extends Resource
     }
 
     /**
+     * Active order version served by the CLOB (2 when the API omits it).
+     *
+     * @throws PolymarketException
+     */
+    public function getVersion(): int
+    {
+        $data = $this->httpClient->get('/version')->json();
+        $version = $data['version'] ?? 2;
+
+        return is_numeric($version) ? (int) $version : 2;
+    }
+
+    /**
      * @return array<string, mixed>
      *
      * @throws PolymarketException

--- a/src/Signing/Eip712Signer.php
+++ b/src/Signing/Eip712Signer.php
@@ -13,20 +13,19 @@ use kornrunner\Signature\Signature;
 use PolymarketPhp\Polymarket\Exceptions\ClobAuthenticationException;
 use PolymarketPhp\Polymarket\Exceptions\SigningException;
 use PolymarketPhp\Polymarket\Signing\TypedData\TypedDataInterface;
+use Throwable;
 
 /**
- * EIP-712 signer for CLOB authentication.
+ * EIP-712 signer. Signs typed structured data with a secp256k1 private key.
+ *
+ * Chain ID is stored here because it belongs to the signer's network context
+ * and must match the domain separator embedded in every payload.
  */
 class Eip712Signer
 {
     private readonly string $privateKey;
 
     private Address $ethAddress;
-
-    public function getAddress(): string
-    {
-        return '0x' . $this->ethAddress->get();
-    }
 
     /**
      * @throws SigningException
@@ -43,11 +42,30 @@ class Eip712Signer
         }
     }
 
+    public function getAddress(): string
+    {
+        return '0x' . $this->ethAddress->get();
+    }
+
+    public function getChainId(): int
+    {
+        return $this->chainId;
+    }
+
+    /**
+     * Sign EIP-712 typed structured data.
+     *
+     * @throws SigningException
+     */
     public function sign(TypedDataInterface $payload): string
     {
-        $hash = $this->hashTypedData($payload);
+        try {
+            $hash = $this->hashTypedData($payload);
 
-        return $this->signHash($hash);
+            return $this->signHash($hash);
+        } catch (Throwable $e) {
+            throw SigningException::eip712Failed($e->getMessage());
+        }
     }
 
     /**
@@ -77,8 +95,6 @@ class Eip712Signer
     /**
      * Hash typed data according to EIP-712.
      *
-     * @param TypedDataInterface $payload
-     * @return string
      * @throws Exception
      */
     private function hashTypedData(TypedDataInterface $payload): string
@@ -101,6 +117,7 @@ class Eip712Signer
             $payload->getMessage()
         );
 
+        // keccak256("\x19\x01" ‖ domainHash ‖ messageHash)
         $encoded = $prefix . hex2bin(substr($domainHash, 2)) . hex2bin(substr($messageHash, 2));
 
         return '0x' . Keccak::hash($encoded, 256);
@@ -112,7 +129,6 @@ class Eip712Signer
      * @param array<array{name: string, type: string}> $types
      * @param array<string, mixed>                     $data
      *
-     *
      * @throws Exception
      */
     private function hashStruct(string $typeName, array $types, array $data): string
@@ -123,13 +139,13 @@ class Eip712Signer
         foreach ($types as $type) {
             $fieldName = $type['name'];
             if (!array_key_exists($fieldName, $data)) {
-                throw new InvalidArgumentException("Missing required field '$fieldName' in $typeName data structure.");
+                throw new InvalidArgumentException(
+                    "Missing required field '{$fieldName}' in {$typeName} data structure."
+                );
             }
-            $value = $data[$fieldName];
-            $encodedValues .= $this->encodeValue($type['type'], $value);
+            $encodedValues .= $this->encodeValue($type['type'], $data[$fieldName]);
         }
 
-        // Concatenate typeHash with encoded values and hash
         $encoded = hex2bin(substr($typeHash, 2)) . hex2bin($encodedValues);
 
         return '0x' . Keccak::hash($encoded, 256);
@@ -138,30 +154,33 @@ class Eip712Signer
     /**
      * Hash a type string according to EIP-712.
      *
-     * @param  array<array{name: string, type: string}>  $types
+     * @param array<array{name: string, type: string}> $types
      *
      * @throws Exception
      */
     private function hashType(string $typeName, array $types): string
     {
-        $typeString = $typeName . '(';
         $parts = [];
         foreach ($types as $type) {
             $parts[] = $type['type'] . ' ' . $type['name'];
         }
-        $typeString .= implode(',', $parts) . ')';
 
-        return '0x' . Keccak::hash($typeString, 256);
+        return '0x' . Keccak::hash($typeName . '(' . implode(',', $parts) . ')', 256);
     }
 
     /**
      * Encode a value according to EIP-712 encoding rules.
+     *
+     * @throws InvalidArgumentException
      */
     private function encodeValue(string $type, mixed $value): string
     {
+        // Dynamic types: keccak256 of the raw bytes
         if ($type === 'string' || $type === 'bytes') {
             if (!is_string($value)) {
-                throw new InvalidArgumentException("Expected string, got " . get_debug_type($value) . ". Value: " . $value);
+                throw new InvalidArgumentException(
+                    "Expected string for type '{$type}', got " . get_debug_type($value)
+                );
             }
 
             return Keccak::hash($value, 256);
@@ -169,43 +188,53 @@ class Eip712Signer
 
         if ($type === 'address') {
             if (!is_string($value)) {
-                throw new InvalidArgumentException("Expected string, got " . get_debug_type($value));
+                throw new InvalidArgumentException(
+                    "Expected string for type 'address', got " . get_debug_type($value)
+                );
             }
-            $address = strtolower(str_replace('0x', '', $value));
 
-            return str_pad($address, 64, '0', STR_PAD_LEFT);
+            return str_pad(strtolower(str_replace('0x', '', $value)), 64, '0', STR_PAD_LEFT);
         }
 
         if ($type === 'uint256' || $type === 'uint8') {
-            if (!is_int($value) && !ctype_digit($value)) {
-                throw new InvalidArgumentException("Expected uint256/uint8, got " . get_debug_type($value) . ". Value: " . $value);
+            if (!is_int($value) && !(is_string($value) && ctype_digit($value))) {
+                throw new InvalidArgumentException(
+                    "Expected integer or numeric string for type '{$type}', got "
+                    . get_debug_type($value)
+                );
             }
 
-            $hex = gmp_strval(gmp_init($value), 16);
-
-            return str_pad($hex, 64, '0', STR_PAD_LEFT);
+            // PHPStan now knows $value is int|string
+            return str_pad(gmp_strval(gmp_init($value), 16), 64, '0', STR_PAD_LEFT);
         }
 
         if ($type === 'bool') {
             return str_pad($value ? '1' : '0', 64, '0', STR_PAD_LEFT);
         }
 
+        // Fixed-size bytes (bytes1..bytes32): right-padded per EIP-712 spec
         if (preg_match('/^bytes(\d+)$/', $type, $matches)) {
             $size = (int) $matches[1];
             if ($size < 1 || $size > 32) {
-                throw new InvalidArgumentException("Invalid bytes size: $type");
+                throw new InvalidArgumentException("Invalid fixed bytes type: '{$type}'");
             }
 
-            $hex = str_replace('0x', '', (string) $value);
-            // Important: Fixed bytes are padded on the RIGHT
-            return str_pad($hex, 64, '0', STR_PAD_RIGHT);
+            if (!is_string($value)) {
+                throw new InvalidArgumentException(
+                    "Expected hex string for type '{$type}', got " . get_debug_type($value)
+                );
+            }
+
+            return str_pad(str_replace('0x', '', $value), 64, '0', STR_PAD_RIGHT);
         }
 
-        throw new InvalidArgumentException("Unsupported type: $type");
+        throw new InvalidArgumentException("Unsupported EIP-712 type: '{$type}'");
     }
 
     /**
-     * @param  string  $hash  Hash to sign (with 0x prefix)
+     * Sign a 32-byte hash and return an Ethereum-style (r ‖ s ‖ v) hex signature.
+     *
+     * @param string $hash Hash to sign (with 0x prefix)
      */
     private function signHash(string $hash): string
     {
@@ -216,7 +245,6 @@ class Eip712Signer
         /** @var Signature $signature */
         $signature = $secp256k1->sign($hashHex, $privateKeyHex);
 
-        // Ethereum signature (r + s + v)
         $r = str_pad(gmp_strval($signature->getR(), 16), 64, '0', STR_PAD_LEFT);
         $s = str_pad(gmp_strval($signature->getS(), 16), 64, '0', STR_PAD_LEFT);
         $v = 27 + $signature->getRecoveryParam();

--- a/src/Signing/Eip712Signer.php
+++ b/src/Signing/Eip712Signer.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PolymarketPhp\Polymarket\Auth\Signer;
+namespace PolymarketPhp\Polymarket\Signing;
 
 use Exception;
 use InvalidArgumentException;
@@ -12,7 +12,7 @@ use kornrunner\Secp256k1;
 use kornrunner\Signature\Signature;
 use PolymarketPhp\Polymarket\Exceptions\ClobAuthenticationException;
 use PolymarketPhp\Polymarket\Exceptions\SigningException;
-use Throwable;
+use PolymarketPhp\Polymarket\Signing\TypedData\TypedDataInterface;
 
 /**
  * EIP-712 signer for CLOB authentication.
@@ -43,33 +43,11 @@ class Eip712Signer
         }
     }
 
-    /**
-     * Sign EIP-712 typed data for CLOB authentication.
-     *
-     * @param  int  $timestamp  Unix timestamp
-     * @param  int  $nonce  Nonce value (default: 0)
-     * @return string Signature as hex string with 0x prefix
-     *
-     * @throws SigningException
-     */
-    public function signClobAuth(int $timestamp, int $nonce = 0): string
+    public function sign(TypedDataInterface $payload): string
     {
-        try {
-            $message = [
-                'address' => strtolower($this->getAddress()),
-                'timestamp' => (string) $timestamp,
-                'nonce' => $nonce,
-                'message' => 'This message attests that I control the given wallet',
-            ];
+        $hash = $this->hashTypedData($payload);
 
-            $domain = $this->buildDomain();
-            $types = $this->buildTypes();
-            $hash = $this->hashTypedData($domain, $types, $message);
-
-            return $this->signHash($hash);
-        } catch (Throwable $e) {
-            throw SigningException::eip712Failed($e->getMessage());
-        }
+        return $this->signHash($hash);
     }
 
     /**
@@ -97,61 +75,32 @@ class Eip712Signer
     }
 
     /**
-     * Build EIP-712 domain separator.
-     *
-     * @return array{name: string, version: string, chainId: int}
-     */
-    private function buildDomain(): array
-    {
-        return [
-            'name' => 'ClobAuthDomain',
-            'version' => '1',
-            'chainId' => $this->chainId,
-        ];
-    }
-
-    /**
-     * Build EIP-712 type definitions.
-     *
-     * @return array<string, array<array{name: string, type: string}>>
-     */
-    private function buildTypes(): array
-    {
-        return [
-            'ClobAuth' => [
-                ['name' => 'address', 'type' => 'address'],
-                ['name' => 'timestamp', 'type' => 'string'],
-                ['name' => 'nonce', 'type' => 'uint256'],
-                ['name' => 'message', 'type' => 'string'],
-            ],
-        ];
-    }
-
-    /**
      * Hash typed data according to EIP-712.
      *
-     * @param array{name: string, version: string, chainId: int}                     $domain
-     * @param array<string, array<array{name: string, type: string}>>                $types
-     * @param array{address: string, timestamp: string, nonce: int, message: string} $message
-     *
+     * @param TypedDataInterface $payload
+     * @return string
      * @throws Exception
      */
-    private function hashTypedData(array $domain, array $types, array $message): string
+    private function hashTypedData(TypedDataInterface $payload): string
     {
         // EIP-712 prefix
         $prefix = "\x19\x01";
 
-        // Hash domain separator
-        $domainHash = $this->hashStruct('EIP712Domain', [
-            ['name' => 'name', 'type' => 'string'],
-            ['name' => 'version', 'type' => 'string'],
-            ['name' => 'chainId', 'type' => 'uint256'],
-        ], $domain);
+        $domainHash = $this->hashStruct(
+            'EIP712Domain',
+            $payload->getDomainTypes(),
+            $payload->getDomain()
+        );
 
-        // Hash message
-        $messageHash = $this->hashStruct('ClobAuth', $types['ClobAuth'], $message);
+        $types = $payload->getTypes();
+        $primaryType = $payload->getPrimaryType();
 
-        // Concatenate and hash: keccak256("\x19\x01" ‖ domainHash ‖ messageHash)
+        $messageHash = $this->hashStruct(
+            $primaryType,
+            $types[$primaryType],
+            $payload->getMessage()
+        );
+
         $encoded = $prefix . hex2bin(substr($domainHash, 2)) . hex2bin(substr($messageHash, 2));
 
         return '0x' . Keccak::hash($encoded, 256);
@@ -172,7 +121,11 @@ class Eip712Signer
 
         $encodedValues = '';
         foreach ($types as $type) {
-            $value = $data[$type['name']];
+            $fieldName = $type['name'];
+            if (!array_key_exists($fieldName, $data)) {
+                throw new InvalidArgumentException("Missing required field '$fieldName' in $typeName data structure.");
+            }
+            $value = $data[$fieldName];
             $encodedValues .= $this->encodeValue($type['type'], $value);
         }
 
@@ -206,9 +159,9 @@ class Eip712Signer
      */
     private function encodeValue(string $type, mixed $value): string
     {
-        if ($type === 'string') {
+        if ($type === 'string' || $type === 'bytes') {
             if (!is_string($value)) {
-                throw new InvalidArgumentException("Expected string, got " . get_debug_type($value));
+                throw new InvalidArgumentException("Expected string, got " . get_debug_type($value) . ". Value: " . $value);
             }
 
             return Keccak::hash($value, 256);
@@ -218,17 +171,34 @@ class Eip712Signer
             if (!is_string($value)) {
                 throw new InvalidArgumentException("Expected string, got " . get_debug_type($value));
             }
-            $address = str_replace('0x', '', $value);
+            $address = strtolower(str_replace('0x', '', $value));
 
             return str_pad($address, 64, '0', STR_PAD_LEFT);
         }
 
-        if ($type === 'uint256') {
-            if (!is_int($value)) {
-                throw new InvalidArgumentException("Expected uint256, got " . get_debug_type($value));
+        if ($type === 'uint256' || $type === 'uint8') {
+            if (!is_int($value) && !ctype_digit($value)) {
+                throw new InvalidArgumentException("Expected uint256/uint8, got " . get_debug_type($value) . ". Value: " . $value);
             }
 
-            return str_pad(dechex($value), 64, '0', STR_PAD_LEFT);
+            $hex = gmp_strval(gmp_init($value), 16);
+
+            return str_pad($hex, 64, '0', STR_PAD_LEFT);
+        }
+
+        if ($type === 'bool') {
+            return str_pad($value ? '1' : '0', 64, '0', STR_PAD_LEFT);
+        }
+
+        if (preg_match('/^bytes(\d+)$/', $type, $matches)) {
+            $size = (int) $matches[1];
+            if ($size < 1 || $size > 32) {
+                throw new InvalidArgumentException("Invalid bytes size: $type");
+            }
+
+            $hex = str_replace('0x', '', (string) $value);
+            // Important: Fixed bytes are padded on the RIGHT
+            return str_pad($hex, 64, '0', STR_PAD_RIGHT);
         }
 
         throw new InvalidArgumentException("Unsupported type: $type");

--- a/src/Signing/Eip712Signer.php
+++ b/src/Signing/Eip712Signer.php
@@ -197,7 +197,7 @@ class Eip712Signer
         }
 
         if ($type === 'uint256' || $type === 'uint8') {
-            if (!is_int($value) && !(is_string($value) && ctype_digit($value))) {
+            if (!is_int($value) && (!is_string($value) || !ctype_digit($value))) {
                 throw new InvalidArgumentException(
                     "Expected integer or numeric string for type '{$type}', got "
                     . get_debug_type($value)

--- a/src/Signing/TypedData/ClobAuthPayload.php
+++ b/src/Signing/TypedData/ClobAuthPayload.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace PolymarketPhp\Polymarket\Signing\TypedData;
+
+class ClobAuthPayload implements TypedDataInterface
+{
+    /**
+     * @param string $address The wallet address
+     * @param int $timestamp Unix timestamp
+     * @param int $nonce Nonce value (usually 0)
+     * @param int $chainId Polygon Chain ID (137)
+     */
+    public function __construct(
+        private readonly string $address,
+        private readonly int $timestamp,
+        private readonly int $nonce = 0,
+        private readonly int $chainId = 137
+    ) {}
+
+    public function getDomain(): array
+    {
+        return [
+            'name'    => 'ClobAuthDomain',
+            'version' => '1',
+            'chainId' => $this->chainId,
+        ];
+    }
+
+    public function getDomainTypes(): array
+    {
+        return [
+            ['name' => 'name', 'type' => 'string'],
+            ['name' => 'version', 'type' => 'string'],
+            ['name' => 'chainId', 'type' => 'uint256'],
+        ];
+    }
+
+    public function getPrimaryType(): string
+    {
+        return 'ClobAuth';
+    }
+
+    public function getTypes(): array
+    {
+        return [
+            'ClobAuth' => [
+                ['name' => 'address', 'type' => 'address'],
+                ['name' => 'timestamp', 'type' => 'string'],
+                ['name' => 'nonce', 'type' => 'uint256'],
+                ['name' => 'message', 'type' => 'string'],
+            ],
+        ];
+    }
+
+    public function getMessage(): array
+    {
+        return [
+            'address'   => strtolower($this->address),
+            'timestamp' => (string) $this->timestamp,
+            'nonce'     => $this->nonce,
+            'message'   => 'This message attests that I control the given wallet',
+        ];
+    }
+}

--- a/src/Signing/TypedData/ClobAuthPayload.php
+++ b/src/Signing/TypedData/ClobAuthPayload.php
@@ -1,14 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PolymarketPhp\Polymarket\Signing\TypedData;
 
+/**
+ * EIP-712 payload for CLOB L1 authentication.
+ */
 class ClobAuthPayload implements TypedDataInterface
 {
     /**
-     * @param string $address The wallet address
-     * @param int $timestamp Unix timestamp
-     * @param int $nonce Nonce value (usually 0)
-     * @param int $chainId Polygon Chain ID (137)
+     * @param string $address  The wallet address
+     * @param int    $timestamp Unix timestamp
+     * @param int    $nonce     Nonce value (usually 0)
+     * @param int    $chainId   Chain ID (137 for Polygon mainnet, 80002 for Amoy testnet)
      */
     public function __construct(
         private readonly string $address,
@@ -29,7 +34,7 @@ class ClobAuthPayload implements TypedDataInterface
     public function getDomainTypes(): array
     {
         return [
-            ['name' => 'name', 'type' => 'string'],
+            ['name' => 'name',    'type' => 'string'],
             ['name' => 'version', 'type' => 'string'],
             ['name' => 'chainId', 'type' => 'uint256'],
         ];
@@ -44,10 +49,10 @@ class ClobAuthPayload implements TypedDataInterface
     {
         return [
             'ClobAuth' => [
-                ['name' => 'address', 'type' => 'address'],
+                ['name' => 'address',   'type' => 'address'],
                 ['name' => 'timestamp', 'type' => 'string'],
-                ['name' => 'nonce', 'type' => 'uint256'],
-                ['name' => 'message', 'type' => 'string'],
+                ['name' => 'nonce',     'type' => 'uint256'],
+                ['name' => 'message',   'type' => 'string'],
             ],
         ];
     }

--- a/src/Signing/TypedData/OrderPayload.php
+++ b/src/Signing/TypedData/OrderPayload.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace PolymarketPhp\Polymarket\Signing\TypedData;
+
+class OrderPayload implements TypedDataInterface
+{
+    public const MAINNET_CHAIN_ID = 137;
+    public const TESTNET_CHAIN_ID = 80002;
+    public const CTF_EXCHANGE_MAINNET = '0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E';
+    public const CTF_EXCHANGE_TESTNET = '0xdFE02Eb6733538f8Ea35D585af8DE5958AD99E40';
+
+    /**
+     * @param array<string, mixed> $orderData
+     * @param string $verifyingContract
+     * @param int $chainId
+     */
+    public function __construct(
+        private readonly array $orderData,
+        private readonly int $chainId = self::MAINNET_CHAIN_ID,
+        private readonly string $verifyingContract = self::CTF_EXCHANGE_MAINNET
+    ) {}
+
+    public function getDomainTypes(): array
+    {
+        return [
+            ['name' => 'name', 'type' => 'string'],
+            ['name' => 'version', 'type' => 'string'],
+            ['name' => 'chainId', 'type' => 'uint256'],
+            ['name' => 'verifyingContract', 'type' => 'address'],
+        ];
+    }
+
+    public function getDomain(): array
+    {
+        return [
+            'name'              => 'Polymarket CTF Exchange',
+            'version'           => '1',
+            'chainId'           => $this->chainId,
+            'verifyingContract' => $this->verifyingContract,
+        ];
+    }
+
+    public function getPrimaryType(): string
+    {
+        return 'Order';
+    }
+
+    public function getTypes(): array
+    {
+        return [
+            'Order' => [
+                ['name' => 'salt', 'type' => 'uint256'],
+                ['name' => 'maker', 'type' => 'address'],
+                ['name' => 'signer', 'type' => 'address'],
+                ['name' => 'taker', 'type' => 'address'],
+                ['name' => 'tokenId', 'type' => 'uint256'],
+                ['name' => 'makerAmount', 'type' => 'uint256'],
+                ['name' => 'takerAmount', 'type' => 'uint256'],
+                ['name' => 'expiration', 'type' => 'uint256'],
+                ['name' => 'nonce', 'type' => 'uint256'],
+                ['name' => 'feeRateBps', 'type' => 'uint256'],
+                ['name' => 'side', 'type' => 'uint8'],
+                ['name' => 'signatureType', 'type' => 'uint8'],
+            ],
+        ];
+    }
+
+    public function getMessage(): array
+    {
+        return $this->orderData;
+    }
+}

--- a/src/Signing/TypedData/OrderPayload.php
+++ b/src/Signing/TypedData/OrderPayload.php
@@ -1,31 +1,49 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PolymarketPhp\Polymarket\Signing\TypedData;
 
+/**
+ * EIP-712 payload for Polymarket CTF Exchange order signing.
+ *
+ * The verifying contract is auto-derived from the chain ID unless overridden
+ * explicitly, so callers only need to pass the chain ID.
+ */
 class OrderPayload implements TypedDataInterface
 {
     public const MAINNET_CHAIN_ID = 137;
+
     public const TESTNET_CHAIN_ID = 80002;
+
     public const CTF_EXCHANGE_MAINNET = '0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E';
+
     public const CTF_EXCHANGE_TESTNET = '0xdFE02Eb6733538f8Ea35D585af8DE5958AD99E40';
+
+    private readonly string $verifyingContract;
 
     /**
      * @param array<string, mixed> $orderData
-     * @param string $verifyingContract
-     * @param int $chainId
+     * @param int                  $chainId           Chain ID – drives contract auto-selection
+     * @param string|null          $verifyingContract Explicit override; derived from chainId when null
      */
     public function __construct(
         private readonly array $orderData,
         private readonly int $chainId = self::MAINNET_CHAIN_ID,
-        private readonly string $verifyingContract = self::CTF_EXCHANGE_MAINNET
-    ) {}
+        ?string $verifyingContract = null,
+    ) {
+        $this->verifyingContract = $verifyingContract ?? match ($this->chainId) {
+            self::TESTNET_CHAIN_ID => self::CTF_EXCHANGE_TESTNET,
+            default => self::CTF_EXCHANGE_MAINNET,
+        };
+    }
 
     public function getDomainTypes(): array
     {
         return [
-            ['name' => 'name', 'type' => 'string'],
-            ['name' => 'version', 'type' => 'string'],
-            ['name' => 'chainId', 'type' => 'uint256'],
+            ['name' => 'name',              'type' => 'string'],
+            ['name' => 'version',           'type' => 'string'],
+            ['name' => 'chainId',           'type' => 'uint256'],
             ['name' => 'verifyingContract', 'type' => 'address'],
         ];
     }
@@ -49,17 +67,17 @@ class OrderPayload implements TypedDataInterface
     {
         return [
             'Order' => [
-                ['name' => 'salt', 'type' => 'uint256'],
-                ['name' => 'maker', 'type' => 'address'],
-                ['name' => 'signer', 'type' => 'address'],
-                ['name' => 'taker', 'type' => 'address'],
-                ['name' => 'tokenId', 'type' => 'uint256'],
-                ['name' => 'makerAmount', 'type' => 'uint256'],
-                ['name' => 'takerAmount', 'type' => 'uint256'],
-                ['name' => 'expiration', 'type' => 'uint256'],
-                ['name' => 'nonce', 'type' => 'uint256'],
-                ['name' => 'feeRateBps', 'type' => 'uint256'],
-                ['name' => 'side', 'type' => 'uint8'],
+                ['name' => 'salt',          'type' => 'uint256'],
+                ['name' => 'maker',         'type' => 'address'],
+                ['name' => 'signer',        'type' => 'address'],
+                ['name' => 'taker',         'type' => 'address'],
+                ['name' => 'tokenId',       'type' => 'uint256'],
+                ['name' => 'makerAmount',   'type' => 'uint256'],
+                ['name' => 'takerAmount',   'type' => 'uint256'],
+                ['name' => 'expiration',    'type' => 'uint256'],
+                ['name' => 'nonce',         'type' => 'uint256'],
+                ['name' => 'feeRateBps',    'type' => 'uint256'],
+                ['name' => 'side',          'type' => 'uint8'],
                 ['name' => 'signatureType', 'type' => 'uint8'],
             ],
         ];

--- a/src/Signing/TypedData/OrderPayload.php
+++ b/src/Signing/TypedData/OrderPayload.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace PolymarketPhp\Polymarket\Signing\TypedData;
 
 /**
- * EIP-712 payload for Polymarket CTF Exchange order signing.
+ * EIP-712 payload for legacy (V1) Polymarket CTF Exchange order signing.
  *
  * The verifying contract is auto-derived from the chain ID unless overridden
  * explicitly, so callers only need to pass the chain ID.
+ *
+ * @deprecated V1-signed orders are rejected since the CLOB V2 cutover on
+ *             2026-04-28. Use {@see OrderPayloadV2} instead.
  */
 class OrderPayload implements TypedDataInterface
 {

--- a/src/Signing/TypedData/OrderPayloadV2.php
+++ b/src/Signing/TypedData/OrderPayloadV2.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PolymarketPhp\Polymarket\Signing\TypedData;
+
+use InvalidArgumentException;
+
+/**
+ * EIP-712 payload for Polymarket CTF Exchange V2/V3 order signing.
+ *
+ * CLOB V2 went live on 2026-04-28: the Order struct dropped `taker`,
+ * `expiration`, `nonce`, and `feeRateBps`, gained `timestamp`, `metadata`,
+ * and `builder`, and the domain version now matches the order version
+ * ("2" or "3"). The verifying contract is auto-derived from the chain ID,
+ * order version, and neg-risk flag unless overridden explicitly.
+ */
+class OrderPayloadV2 implements TypedDataInterface
+{
+    public const MAINNET_CHAIN_ID = 137;
+
+    public const TESTNET_CHAIN_ID = 80002;
+
+    /** Exchange V2 contracts are deployed at the same address on Polygon and Amoy. */
+    public const CTF_EXCHANGE_V2 = '0xE111180000d2663C0091e4f400237545B87B996B';
+
+    public const NEG_RISK_CTF_EXCHANGE_V2 = '0xe2222d279d744050d28e00520010520000310F59';
+
+    /** Exchange V3 has no separate neg-risk deployment. */
+    public const CTF_EXCHANGE_V3_MAINNET = '0xe3333700cA9d93003F00f0F71f8515005F6c00Aa';
+
+    public const CTF_EXCHANGE_V3_TESTNET = '0x9fE6e61422AdB6F610d8597F9684b16912D50C3D';
+
+    public const BYTES32_ZERO = '0x0000000000000000000000000000000000000000000000000000000000000000';
+
+    private readonly string $verifyingContract;
+
+    /**
+     * @param array<string, mixed> $orderData
+     * @param int                  $chainId           Chain ID – drives contract auto-selection
+     * @param bool                 $negRisk           Sign against the neg-risk exchange (version 2 only)
+     * @param int                  $version           Order version (2 or 3), also the domain version
+     * @param string|null          $verifyingContract Explicit override; derived when null
+     */
+    public function __construct(
+        private readonly array $orderData,
+        private readonly int $chainId = self::MAINNET_CHAIN_ID,
+        private readonly bool $negRisk = false,
+        private readonly int $version = 2,
+        ?string $verifyingContract = null,
+    ) {
+        if (!in_array($this->version, [2, 3], true)) {
+            throw new InvalidArgumentException(
+                "Unsupported order version {$this->version}; supported versions are 2 and 3."
+            );
+        }
+
+        $this->verifyingContract = $verifyingContract ?? $this->deriveContract();
+    }
+
+    public function getDomainTypes(): array
+    {
+        return [
+            ['name' => 'name',              'type' => 'string'],
+            ['name' => 'version',           'type' => 'string'],
+            ['name' => 'chainId',           'type' => 'uint256'],
+            ['name' => 'verifyingContract', 'type' => 'address'],
+        ];
+    }
+
+    public function getDomain(): array
+    {
+        return [
+            'name'              => 'Polymarket CTF Exchange',
+            'version'           => (string) $this->version,
+            'chainId'           => $this->chainId,
+            'verifyingContract' => $this->verifyingContract,
+        ];
+    }
+
+    public function getPrimaryType(): string
+    {
+        return 'Order';
+    }
+
+    public function getTypes(): array
+    {
+        return [
+            'Order' => [
+                ['name' => 'salt',          'type' => 'uint256'],
+                ['name' => 'maker',         'type' => 'address'],
+                ['name' => 'signer',        'type' => 'address'],
+                ['name' => 'tokenId',       'type' => 'uint256'],
+                ['name' => 'makerAmount',   'type' => 'uint256'],
+                ['name' => 'takerAmount',   'type' => 'uint256'],
+                ['name' => 'side',          'type' => 'uint8'],
+                ['name' => 'signatureType', 'type' => 'uint8'],
+                ['name' => 'timestamp',     'type' => 'uint256'],
+                ['name' => 'metadata',      'type' => 'bytes32'],
+                ['name' => 'builder',       'type' => 'bytes32'],
+            ],
+        ];
+    }
+
+    public function getMessage(): array
+    {
+        return $this->orderData;
+    }
+
+    private function deriveContract(): string
+    {
+        if ($this->version === 3) {
+            return $this->chainId === self::TESTNET_CHAIN_ID
+                ? self::CTF_EXCHANGE_V3_TESTNET
+                : self::CTF_EXCHANGE_V3_MAINNET;
+        }
+
+        return $this->negRisk
+            ? self::NEG_RISK_CTF_EXCHANGE_V2
+            : self::CTF_EXCHANGE_V2;
+    }
+}

--- a/src/Signing/TypedData/TypedDataInterface.php
+++ b/src/Signing/TypedData/TypedDataInterface.php
@@ -1,21 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PolymarketPhp\Polymarket\Signing\TypedData;
 
 interface TypedDataInterface
 {
     /**
-     * @return array{name: string, version: string, chainId: int, verifyingContract?: string, salt?: string}
+     * @return array{name: string, version: string, chainId: int, verifyingContract?: string}
      */
     public function getDomain(): array;
 
     /**
-     * @return array{array{name: string, type: string}}
+     * @return list<array{name: string, type: string}>
      */
     public function getDomainTypes(): array;
 
     /**
-     * @return array<string, array<array{name: string, type: string}>>
+     * @return array<string, list<array{name: string, type: string}>>
      */
     public function getTypes(): array;
 

--- a/src/Signing/TypedData/TypedDataInterface.php
+++ b/src/Signing/TypedData/TypedDataInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace PolymarketPhp\Polymarket\Signing\TypedData;
+
+interface TypedDataInterface
+{
+    /**
+     * @return array{name: string, version: string, chainId: int, verifyingContract?: string, salt?: string}
+     */
+    public function getDomain(): array;
+
+    /**
+     * @return array{array{name: string, type: string}}
+     */
+    public function getDomainTypes(): array;
+
+    /**
+     * @return array<string, array<array{name: string, type: string}>>
+     */
+    public function getTypes(): array;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getMessage(): array;
+
+    public function getPrimaryType(): string;
+}

--- a/tests/Feature/Clob/OrdersPostTest.php
+++ b/tests/Feature/Clob/OrdersPostTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+use PolymarketPhp\Polymarket\Enums\OrderSide;
+use PolymarketPhp\Polymarket\Enums\OrderType;
+use PolymarketPhp\Polymarket\Enums\SignatureType;
+use PolymarketPhp\Polymarket\Exceptions\PolymarketException;
+use PolymarketPhp\Polymarket\Http\FakeGuzzleHttpClient;
+use PolymarketPhp\Polymarket\Resources\Clob\Orders;
+use PolymarketPhp\Polymarket\Signing\Eip712Signer;
+
+// Hardhat account #0 — a public test vector, safe to commit.
+const ORDERS_POST_TEST_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+const ORDERS_POST_TEST_ADDRESS = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
+
+/**
+ * Build a complete, valid post() input array.
+ *
+ * @return array<string, mixed>
+ */
+function buildValidPostInput(OrderSide $side = OrderSide::BUY): array
+{
+    return [
+        'order' => [
+            'maker'         => ORDERS_POST_TEST_ADDRESS,
+            'signer'        => ORDERS_POST_TEST_ADDRESS,
+            'taker'         => '0x0000000000000000000000000000000000000000',
+            'tokenId'       => '71321045679252212594626385532706912750332728571942532289631379312455583992563',
+            'makerAmount'   => '100000',
+            'takerAmount'   => '100000',
+            'expiration'    => 0,
+            'nonce'         => 0,
+            'feeRateBps'    => 0,
+            'side'          => $side,
+            'signatureType' => SignatureType::EOA->value,
+            'salt'          => 12_345,
+        ],
+        'owner'     => ORDERS_POST_TEST_ADDRESS,
+        'orderType' => OrderType::GTC->value,
+        'deferExec' => false,
+    ];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeOrders(?Eip712Signer $signer = null): array
+{
+    $fakeHttp = new FakeGuzzleHttpClient();
+    $orders = new Orders($signer, $fakeHttp);
+
+    return [$orders, $fakeHttp];
+}
+
+// ---------------------------------------------------------------------------
+
+describe('Orders::post() – authentication guard', function (): void {
+    it('throws PolymarketException when no signer is configured', function (): void {
+        [$orders] = makeOrders(null);
+
+        expect(fn () => $orders->post(buildValidPostInput()))
+            ->toThrow(PolymarketException::class, 'authentication');
+    });
+});
+
+describe('Orders::post() – HTTP behaviour', function (): void {
+    it('sends a POST request to the /order endpoint', function (): void {
+        [$orders, $fakeHttp] = makeOrders(new Eip712Signer(ORDERS_POST_TEST_KEY, 137));
+        $fakeHttp->addJsonResponse('POST', '/order', ['success' => true, 'orderID' => 'abc123']);
+
+        $result = $orders->post(buildValidPostInput());
+
+        expect($result['success'])->toBeTrue()
+            ->and($fakeHttp->hasRequest('POST', '/order'))->toBeTrue();
+    });
+
+    it('returns the decoded JSON response from the CLOB API', function (): void {
+        [$orders, $fakeHttp] = makeOrders(new Eip712Signer(ORDERS_POST_TEST_KEY, 137));
+        $fakeHttp->addJsonResponse('POST', '/order', ['orderID' => 'xyz-999', 'status' => 'pending']);
+
+        $result = $orders->post(buildValidPostInput());
+
+        expect($result)->toBe(['orderID' => 'xyz-999', 'status' => 'pending']);
+    });
+});
+
+describe('Orders::post() – signature', function (): void {
+    it('adds a 0x-prefixed 65-byte signature to the order sub-array', function (): void {
+        [$orders, $fakeHttp] = makeOrders(new Eip712Signer(ORDERS_POST_TEST_KEY, 137));
+        $fakeHttp->addJsonResponse('POST', '/order', ['success' => true]);
+
+        $orders->post(buildValidPostInput());
+
+        $request = $fakeHttp->getRequest('POST', '/order');
+
+        expect($request)->not->toBeNull()
+            ->and($request['data']['order'])->toHaveKey('signature')
+            ->and($request['data']['order']['signature'])->toStartWith('0x')
+            ->and(strlen((string) $request['data']['order']['signature']))->toBe(132);
+    });
+
+    it('produces the same signature for identical inputs (secp256k1 RFC 6979)', function (): void {
+        $signer = new Eip712Signer(ORDERS_POST_TEST_KEY, 137);
+
+        [$orders1, $fakeHttp1] = makeOrders($signer);
+        $fakeHttp1->addJsonResponse('POST', '/order', ['success' => true]);
+        $orders1->post(buildValidPostInput());
+        $sig1 = $fakeHttp1->getRequest('POST', '/order')['data']['order']['signature'];
+
+        [$orders2, $fakeHttp2] = makeOrders($signer);
+        $fakeHttp2->addJsonResponse('POST', '/order', ['success' => true]);
+        $orders2->post(buildValidPostInput());
+        $sig2 = $fakeHttp2->getRequest('POST', '/order')['data']['order']['signature'];
+
+        expect($sig1)->toBe($sig2);
+    });
+});
+
+describe('Orders::post() – payload shape sent to API', function (): void {
+    it('converts the OrderSide enum to its string value for the API', function (): void {
+        [$orders, $fakeHttp] = makeOrders(new Eip712Signer(ORDERS_POST_TEST_KEY, 137));
+        $fakeHttp->addJsonResponse('POST', '/order', ['success' => true]);
+
+        $orders->post(buildValidPostInput(OrderSide::BUY));
+        $order = $fakeHttp->getRequest('POST', '/order')['data']['order'];
+
+        expect($order['side'])->toBe('BUY');
+    });
+
+    it('converts the SELL side enum to its string value', function (): void {
+        [$orders, $fakeHttp] = makeOrders(new Eip712Signer(ORDERS_POST_TEST_KEY, 137));
+        $fakeHttp->addJsonResponse('POST', '/order', ['success' => true]);
+
+        $orders->post(buildValidPostInput(OrderSide::SELL));
+        $order = $fakeHttp->getRequest('POST', '/order')['data']['order'];
+
+        expect($order['side'])->toBe('SELL');
+    });
+
+    it('normalises all numeric order fields to strings for the CLOB API', function (): void {
+        [$orders, $fakeHttp] = makeOrders(new Eip712Signer(ORDERS_POST_TEST_KEY, 137));
+        $fakeHttp->addJsonResponse('POST', '/order', ['success' => true]);
+
+        $orders->post(buildValidPostInput());
+        $order = $fakeHttp->getRequest('POST', '/order')['data']['order'];
+
+        expect($order['salt'])->toBeString()
+            ->and($order['tokenId'])->toBeString()
+            ->and($order['makerAmount'])->toBeString()
+            ->and($order['takerAmount'])->toBeString()
+            ->and($order['expiration'])->toBeString()
+            ->and($order['nonce'])->toBeString()
+            ->and($order['feeRateBps'])->toBeString();
+    });
+
+    it('forwards owner, orderType, and deferExec to the top-level payload', function (): void {
+        [$orders, $fakeHttp] = makeOrders(new Eip712Signer(ORDERS_POST_TEST_KEY, 137));
+        $fakeHttp->addJsonResponse('POST', '/order', ['success' => true]);
+
+        $orders->post(buildValidPostInput());
+        $payload = $fakeHttp->getRequest('POST', '/order')['data'];
+
+        expect($payload['owner'])->toBe(ORDERS_POST_TEST_ADDRESS)
+            ->and($payload['orderType'])->toBe(OrderType::GTC->value)
+            ->and($payload['deferExec'])->toBeFalse();
+    });
+
+    it('defaults deferExec to false when omitted', function (): void {
+        [$orders, $fakeHttp] = makeOrders(new Eip712Signer(ORDERS_POST_TEST_KEY, 137));
+        $fakeHttp->addJsonResponse('POST', '/order', ['success' => true]);
+
+        $input = buildValidPostInput();
+        unset($input['deferExec']);
+        $orders->post($input);
+
+        $payload = $fakeHttp->getRequest('POST', '/order')['data'];
+
+        expect($payload['deferExec'])->toBeFalse();
+    });
+});

--- a/tests/Feature/Clob/OrdersPostTest.php
+++ b/tests/Feature/Clob/OrdersPostTest.php
@@ -6,6 +6,7 @@ use PolymarketPhp\Polymarket\Enums\OrderSide;
 use PolymarketPhp\Polymarket\Enums\OrderType;
 use PolymarketPhp\Polymarket\Enums\SignatureType;
 use PolymarketPhp\Polymarket\Exceptions\PolymarketException;
+use PolymarketPhp\Polymarket\Exceptions\SigningException;
 use PolymarketPhp\Polymarket\Http\FakeGuzzleHttpClient;
 use PolymarketPhp\Polymarket\Resources\Clob\Orders;
 use PolymarketPhp\Polymarket\Signing\Eip712Signer;
@@ -15,7 +16,7 @@ const ORDERS_POST_TEST_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efc
 const ORDERS_POST_TEST_ADDRESS = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
 
 /**
- * Build a complete, valid post() input array.
+ * Build a complete, valid post() input array using the official V2 fixture.
  *
  * @return array<string, mixed>
  */
@@ -25,16 +26,13 @@ function buildValidPostInput(OrderSide $side = OrderSide::BUY): array
         'order' => [
             'maker'         => ORDERS_POST_TEST_ADDRESS,
             'signer'        => ORDERS_POST_TEST_ADDRESS,
-            'taker'         => '0x0000000000000000000000000000000000000000',
-            'tokenId'       => '71321045679252212594626385532706912750332728571942532289631379312455583992563',
-            'makerAmount'   => '100000',
-            'takerAmount'   => '100000',
-            'expiration'    => 0,
-            'nonce'         => 0,
-            'feeRateBps'    => 0,
+            'tokenId'       => '1234',
+            'makerAmount'   => '100000000',
+            'takerAmount'   => '50000000',
             'side'          => $side,
             'signatureType' => SignatureType::EOA->value,
-            'salt'          => 12_345,
+            'salt'          => 479_249_096_354,
+            'timestamp'     => '1780449126930',
         ],
         'owner'     => ORDERS_POST_TEST_ADDRESS,
         'orderType' => OrderType::GTC->value,
@@ -86,47 +84,78 @@ describe('Orders::post() – HTTP behaviour', function (): void {
     });
 });
 
-describe('Orders::post() – signature', function (): void {
-    it('adds a 0x-prefixed 65-byte signature to the order sub-array', function (): void {
+describe('Orders::post() – V2 signature', function (): void {
+    it('produces the exact reference signature for the official V2 fixture', function (): void {
         [$orders, $fakeHttp] = makeOrders(new Eip712Signer(ORDERS_POST_TEST_KEY, 137));
         $fakeHttp->addJsonResponse('POST', '/order', ['success' => true]);
 
         $orders->post(buildValidPostInput());
+        $order = $fakeHttp->getRequest('POST', '/order')['data']['order'];
 
-        $request = $fakeHttp->getRequest('POST', '/order');
-
-        expect($request)->not->toBeNull()
-            ->and($request['data']['order'])->toHaveKey('signature')
-            ->and($request['data']['order']['signature'])->toStartWith('0x')
-            ->and(strlen((string) $request['data']['order']['signature']))->toBe(132);
+        // Generated with eth-account 0.13.7 (reference implementation) for
+        // the fixture above on Polygon mainnet against the V2 exchange.
+        expect($order['signature'])->toBe(
+            '0x745070770d383e6f4e6431858070edacbea294ed0e2b16f147127edafc51b59a'
+            . '6e788aaeda02cce5989ee10cc983a4045313e1ec7075c5a5b84f6212b097d36a1b'
+        );
     });
 
-    it('produces the same signature for identical inputs (secp256k1 RFC 6979)', function (): void {
-        $signer = new Eip712Signer(ORDERS_POST_TEST_KEY, 137);
+    it('signs against the neg-risk exchange when negRisk is true', function (): void {
+        [$orders, $fakeHttp] = makeOrders(new Eip712Signer(ORDERS_POST_TEST_KEY, 137));
+        $fakeHttp->addJsonResponse('POST', '/order', ['success' => true]);
 
-        [$orders1, $fakeHttp1] = makeOrders($signer);
-        $fakeHttp1->addJsonResponse('POST', '/order', ['success' => true]);
-        $orders1->post(buildValidPostInput());
-        $sig1 = $fakeHttp1->getRequest('POST', '/order')['data']['order']['signature'];
+        $input = buildValidPostInput();
+        $input['negRisk'] = true;
+        $orders->post($input);
+        $order = $fakeHttp->getRequest('POST', '/order')['data']['order'];
 
-        [$orders2, $fakeHttp2] = makeOrders($signer);
-        $fakeHttp2->addJsonResponse('POST', '/order', ['success' => true]);
-        $orders2->post(buildValidPostInput());
-        $sig2 = $fakeHttp2->getRequest('POST', '/order')['data']['order']['signature'];
+        expect($order['signature'])->toBe(
+            '0x0cf7ad04271cdfe92e93422d1ea1154b0c297b101f08c030f4b7555d7e63419e'
+            . '5372c7b3ba494ebf1a54e9df77b1137b1f3ee76017e4c5bb0cdc8073885e194a1c'
+        );
+    });
 
-        expect($sig1)->toBe($sig2);
+    it('signs a version 3 order against the V3 exchange domain', function (): void {
+        [$orders, $fakeHttp] = makeOrders(new Eip712Signer(ORDERS_POST_TEST_KEY, 137));
+        $fakeHttp->addJsonResponse('POST', '/order', ['success' => true]);
+
+        $input = buildValidPostInput();
+        $input['version'] = 3;
+        $orders->post($input);
+        $order = $fakeHttp->getRequest('POST', '/order')['data']['order'];
+
+        expect($order['signature'])->toBe(
+            '0x1406e9ec3bcaf3101971b2b612b5680c222e61df601ccc9a9f1f37144f10f49f'
+            . '408bbed7b390357803b2d1b6562a604335b790582211e76401ddbe6ae2ebc0dd1c'
+        );
+    });
+
+    it('rejects POLY_1271 orders with a clear signing error', function (): void {
+        [$orders] = makeOrders(new Eip712Signer(ORDERS_POST_TEST_KEY, 137));
+
+        $input = buildValidPostInput();
+        $input['order']['signatureType'] = SignatureType::POLY_1271->value;
+
+        expect(fn () => $orders->post($input))
+            ->toThrow(SigningException::class, 'POLY_1271');
     });
 });
 
-describe('Orders::post() – payload shape sent to API', function (): void {
-    it('converts the OrderSide enum to its string value for the API', function (): void {
+describe('Orders::post() – V2 payload shape sent to API', function (): void {
+    it('sends the V2 wire format: side as string, salt as int, amounts as strings', function (): void {
         [$orders, $fakeHttp] = makeOrders(new Eip712Signer(ORDERS_POST_TEST_KEY, 137));
         $fakeHttp->addJsonResponse('POST', '/order', ['success' => true]);
 
         $orders->post(buildValidPostInput(OrderSide::BUY));
         $order = $fakeHttp->getRequest('POST', '/order')['data']['order'];
 
-        expect($order['side'])->toBe('BUY');
+        expect($order['side'])->toBe('BUY')
+            ->and($order['salt'])->toBe(479_249_096_354)
+            ->and($order['tokenId'])->toBeString()
+            ->and($order['makerAmount'])->toBeString()
+            ->and($order['takerAmount'])->toBeString()
+            ->and($order['timestamp'])->toBeString()
+            ->and($order['expiration'])->toBe('0');
     });
 
     it('converts the SELL side enum to its string value', function (): void {
@@ -139,35 +168,60 @@ describe('Orders::post() – payload shape sent to API', function (): void {
         expect($order['side'])->toBe('SELL');
     });
 
-    it('normalises all numeric order fields to strings for the CLOB API', function (): void {
+    it('does not send the removed V1 fields', function (): void {
         [$orders, $fakeHttp] = makeOrders(new Eip712Signer(ORDERS_POST_TEST_KEY, 137));
         $fakeHttp->addJsonResponse('POST', '/order', ['success' => true]);
 
         $orders->post(buildValidPostInput());
         $order = $fakeHttp->getRequest('POST', '/order')['data']['order'];
 
-        expect($order['salt'])->toBeString()
-            ->and($order['tokenId'])->toBeString()
-            ->and($order['makerAmount'])->toBeString()
-            ->and($order['takerAmount'])->toBeString()
-            ->and($order['expiration'])->toBeString()
-            ->and($order['nonce'])->toBeString()
-            ->and($order['feeRateBps'])->toBeString();
+        expect($order)->not->toHaveKey('taker')
+            ->and($order)->not->toHaveKey('nonce')
+            ->and($order)->not->toHaveKey('feeRateBps');
     });
 
-    it('forwards owner, orderType, and deferExec to the top-level payload', function (): void {
+    it('defaults metadata and builder to zero bytes32 in the payload', function (): void {
         [$orders, $fakeHttp] = makeOrders(new Eip712Signer(ORDERS_POST_TEST_KEY, 137));
         $fakeHttp->addJsonResponse('POST', '/order', ['success' => true]);
 
         $orders->post(buildValidPostInput());
+        $order = $fakeHttp->getRequest('POST', '/order')['data']['order'];
+
+        expect($order['metadata'])->toBe('0x' . str_repeat('0', 64))
+            ->and($order['builder'])->toBe('0x' . str_repeat('0', 64));
+    });
+
+    it('fills salt and timestamp automatically when omitted', function (): void {
+        [$orders, $fakeHttp] = makeOrders(new Eip712Signer(ORDERS_POST_TEST_KEY, 137));
+        $fakeHttp->addJsonResponse('POST', '/order', ['success' => true]);
+
+        $input = buildValidPostInput();
+        unset($input['order']['salt'], $input['order']['timestamp']);
+        $orders->post($input);
+        $order = $fakeHttp->getRequest('POST', '/order')['data']['order'];
+
+        // Timestamp must be now in milliseconds (13-digit range).
+        expect($order['salt'])->toBeInt()->toBeGreaterThan(0)
+            ->and($order['timestamp'])->toBeString()
+            ->and((int) $order['timestamp'])->toBeGreaterThan(1_700_000_000_000);
+    });
+
+    it('forwards owner, orderType, deferExec, and postOnly to the top-level payload', function (): void {
+        [$orders, $fakeHttp] = makeOrders(new Eip712Signer(ORDERS_POST_TEST_KEY, 137));
+        $fakeHttp->addJsonResponse('POST', '/order', ['success' => true]);
+
+        $input = buildValidPostInput();
+        $input['postOnly'] = true;
+        $orders->post($input);
         $payload = $fakeHttp->getRequest('POST', '/order')['data'];
 
         expect($payload['owner'])->toBe(ORDERS_POST_TEST_ADDRESS)
             ->and($payload['orderType'])->toBe(OrderType::GTC->value)
-            ->and($payload['deferExec'])->toBeFalse();
+            ->and($payload['deferExec'])->toBeFalse()
+            ->and($payload['postOnly'])->toBeTrue();
     });
 
-    it('defaults deferExec to false when omitted', function (): void {
+    it('defaults deferExec and postOnly to false when omitted', function (): void {
         [$orders, $fakeHttp] = makeOrders(new Eip712Signer(ORDERS_POST_TEST_KEY, 137));
         $fakeHttp->addJsonResponse('POST', '/order', ['success' => true]);
 
@@ -177,6 +231,21 @@ describe('Orders::post() – payload shape sent to API', function (): void {
 
         $payload = $fakeHttp->getRequest('POST', '/order')['data'];
 
-        expect($payload['deferExec'])->toBeFalse();
+        expect($payload['deferExec'])->toBeFalse()
+            ->and($payload['postOnly'])->toBeFalse();
+    });
+
+    it('does not leak the negRisk and version signing options into the payload', function (): void {
+        [$orders, $fakeHttp] = makeOrders(new Eip712Signer(ORDERS_POST_TEST_KEY, 137));
+        $fakeHttp->addJsonResponse('POST', '/order', ['success' => true]);
+
+        $input = buildValidPostInput();
+        $input['negRisk'] = true;
+        $input['version'] = 2;
+        $orders->post($input);
+        $payload = $fakeHttp->getRequest('POST', '/order')['data'];
+
+        expect($payload)->not->toHaveKey('negRisk')
+            ->and($payload)->not->toHaveKey('version');
     });
 });

--- a/tests/Feature/Clob/ServerTest.php
+++ b/tests/Feature/Clob/ServerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use PolymarketPhp\Polymarket\Client;
 use PolymarketPhp\Polymarket\Http\FakeGuzzleHttpClient;
+use PolymarketPhp\Polymarket\Http\Response;
 
 beforeEach(function (): void {
     $this->fakeHttp = new FakeGuzzleHttpClient();
@@ -12,28 +13,25 @@ beforeEach(function (): void {
 
 describe('Server::healthCheck()', function (): void {
     it('performs health check', function (): void {
-        $healthData = ['status' => 'ok', 'timestamp' => 1234567890];
+        $healthData = "OK";
 
-        $this->fakeHttp->addJsonResponse('GET', '/', $healthData);
+        $this->fakeHttp->addResponse('GET', '/', new Response(200, [], $healthData));
 
         $result = $this->client->clob()->server()->healthCheck();
 
-        expect($result)->toBeArray()
-            ->and($result['status'])->toBe('ok');
+        expect($result)->toBe('OK');
     });
 });
 
 describe('Server::getTime()', function (): void {
     it('retrieves current server timestamp', function (): void {
-        $timeData = ['timestamp' => 1234567890, 'iso' => '2025-01-15T12:00:00Z'];
+        $timeData = "1234567890";
 
-        $this->fakeHttp->addJsonResponse('GET', '/time', $timeData);
+        $this->fakeHttp->addResponse('GET', '/time', new Response(200, [], $timeData));
 
         $result = $this->client->clob()->server()->getTime();
 
-        expect($result)->toBeArray()
-            ->and($result)->toHaveKey('timestamp')
-            ->and($result['timestamp'])->toBe(1234567890);
+        expect($result)->toBe(1234567890);
     });
 });
 

--- a/tests/Feature/Clob/ServerTest.php
+++ b/tests/Feature/Clob/ServerTest.php
@@ -35,6 +35,24 @@ describe('Server::getTime()', function (): void {
     });
 });
 
+describe('Server::getVersion()', function (): void {
+    it('retrieves the active order version from the CLOB API', function (): void {
+        $this->fakeHttp->addJsonResponse('GET', '/version', ['version' => 2]);
+
+        $result = $this->client->clob()->server()->getVersion();
+
+        expect($result)->toBe(2);
+    });
+
+    it('defaults to version 2 when the API omits the version field', function (): void {
+        $this->fakeHttp->addJsonResponse('GET', '/version', []);
+
+        $result = $this->client->clob()->server()->getVersion();
+
+        expect($result)->toBe(2);
+    });
+});
+
 describe('Server::getFeeRate()', function (): void {
     it('fetches fee rate for token', function (): void {
         $feeData = ['fee_rate_bps' => 10, 'fee_percentage' => '0.10'];

--- a/tests/Unit/Enums/SignatureTypeTest.php
+++ b/tests/Unit/Enums/SignatureTypeTest.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use PolymarketPhp\Polymarket\Enums\SignatureType;
+
+describe('SignatureType', function (): void {
+    it('matches the canonical CLOB V2 signature type values', function (): void {
+        expect(SignatureType::EOA->value)->toBe(0)
+            ->and(SignatureType::POLY_PROXY->value)->toBe(1)
+            ->and(SignatureType::POLY_GNOSIS_SAFE->value)->toBe(2)
+            ->and(SignatureType::POLY_1271->value)->toBe(3);
+    });
+});

--- a/tests/Unit/Signing/Eip712SignerTest.php
+++ b/tests/Unit/Signing/Eip712SignerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use PolymarketPhp\Polymarket\Exceptions\ClobAuthenticationException;
+use PolymarketPhp\Polymarket\Signing\Eip712Signer;
+use PolymarketPhp\Polymarket\Signing\TypedData\ClobAuthPayload;
+
+// Hardhat account #0 – a well-known test vector, safe to commit.
+const EIP712_TEST_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+const EIP712_TEST_ADDRESS = '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266';
+
+describe('Eip712Signer::__construct()', function (): void {
+    it('derives the correct Ethereum address from the private key', function (): void {
+        $signer = new Eip712Signer(EIP712_TEST_KEY);
+
+        expect(strtolower($signer->getAddress()))->toBe(EIP712_TEST_ADDRESS);
+    });
+
+    it('accepts a private key without the 0x prefix', function (): void {
+        $keyWithout0x = substr(EIP712_TEST_KEY, 2);
+        $signer = new Eip712Signer($keyWithout0x);
+
+        expect(strtolower($signer->getAddress()))->toBe(EIP712_TEST_ADDRESS);
+    });
+
+    it('throws ClobAuthenticationException for a non-hex private key', function (): void {
+        expect(fn (): Eip712Signer => new Eip712Signer('not-a-valid-private-key'))
+            ->toThrow(ClobAuthenticationException::class);
+    });
+
+    it('throws ClobAuthenticationException for a key with wrong byte length', function (): void {
+        // 31 bytes (62 hex chars) — one byte short
+        expect(fn (): Eip712Signer => new Eip712Signer('0x' . str_repeat('ab', 31)))
+            ->toThrow(ClobAuthenticationException::class);
+    });
+});
+
+describe('Eip712Signer::getChainId()', function (): void {
+    it('returns 137 (mainnet) by default', function (): void {
+        $signer = new Eip712Signer(EIP712_TEST_KEY);
+
+        expect($signer->getChainId())->toBe(137);
+    });
+
+    it('returns the chain ID provided at construction time', function (): void {
+        $signer = new Eip712Signer(EIP712_TEST_KEY, 80002);
+
+        expect($signer->getChainId())->toBe(80002);
+    });
+});
+
+describe('Eip712Signer::sign()', function (): void {
+    it('returns a valid 0x-prefixed 65-byte Ethereum signature', function (): void {
+        $signer = new Eip712Signer(EIP712_TEST_KEY, 137);
+        $payload = new ClobAuthPayload($signer->getAddress(), 1_234_567_890, 0, 137);
+
+        $sig = $signer->sign($payload);
+
+        // 0x + 32 bytes r + 32 bytes s + 1 byte v = 0x + 130 hex chars = 132 chars total
+        expect($sig)->toStartWith('0x')
+            ->and(strlen($sig))->toBe(132);
+    });
+
+    it('produces deterministic signatures for the same key and payload', function (): void {
+        $signer = new Eip712Signer(EIP712_TEST_KEY, 137);
+        $payload = new ClobAuthPayload($signer->getAddress(), 1_234_567_890, 0, 137);
+
+        expect($signer->sign($payload))->toBe($signer->sign($payload));
+    });
+
+    it('produces different signatures for different timestamps', function (): void {
+        $signer = new Eip712Signer(EIP712_TEST_KEY, 137);
+        $payload1 = new ClobAuthPayload($signer->getAddress(), 1_000_000, 0, 137);
+        $payload2 = new ClobAuthPayload($signer->getAddress(), 2_000_000, 0, 137);
+
+        expect($signer->sign($payload1))->not->toBe($signer->sign($payload2));
+    });
+
+    it('produces different signatures for mainnet vs testnet chain IDs', function (): void {
+        $signerMainnet = new Eip712Signer(EIP712_TEST_KEY, 137);
+        $signerTestnet = new Eip712Signer(EIP712_TEST_KEY, 80002);
+
+        $payloadMainnet = new ClobAuthPayload($signerMainnet->getAddress(), 1_000_000, 0, 137);
+        $payloadTestnet = new ClobAuthPayload($signerTestnet->getAddress(), 1_000_000, 0, 80002);
+
+        expect($signerMainnet->sign($payloadMainnet))
+            ->not->toBe($signerTestnet->sign($payloadTestnet));
+    });
+});

--- a/tests/Unit/Signing/Eip712SignerV2GoldenTest.php
+++ b/tests/Unit/Signing/Eip712SignerV2GoldenTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+use PolymarketPhp\Polymarket\Signing\Eip712Signer;
+use PolymarketPhp\Polymarket\Signing\TypedData\OrderPayloadV2;
+
+/**
+ * Golden-value tests for V2 order signing.
+ *
+ * Expected signatures were generated with eth-account 0.13.7 — the reference
+ * implementation used by Polymarket's official py-clob-client-v2 — for the
+ * fixture below (Hardhat dev account #0, a public test vector).
+ */
+
+// Hardhat account #0 — a public test vector, safe to commit.
+const GOLDEN_V2_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+const GOLDEN_V2_ADDRESS = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
+
+/**
+ * The official fixture from py-clob-client-v2's builder tests.
+ *
+ * @return array<string, mixed>
+ */
+function goldenOrderDataV2(): array
+{
+    return [
+        'salt'          => '479249096354',
+        'maker'         => GOLDEN_V2_ADDRESS,
+        'signer'        => GOLDEN_V2_ADDRESS,
+        'tokenId'       => '1234',
+        'makerAmount'   => '100000000',
+        'takerAmount'   => '50000000',
+        'side'          => 0,
+        'signatureType' => 0,
+        'timestamp'     => '1780449126930',
+        'metadata'      => OrderPayloadV2::BYTES32_ZERO,
+        'builder'       => OrderPayloadV2::BYTES32_ZERO,
+    ];
+}
+
+describe('Eip712Signer + OrderPayloadV2 – golden signatures', function (): void {
+    it('matches the reference signature on Polygon mainnet (V2 exchange)', function (): void {
+        $signer = new Eip712Signer(GOLDEN_V2_KEY, 137);
+
+        $signature = $signer->sign(new OrderPayloadV2(goldenOrderDataV2(), 137));
+
+        expect($signature)->toBe(
+            '0x745070770d383e6f4e6431858070edacbea294ed0e2b16f147127edafc51b59a'
+            . '6e788aaeda02cce5989ee10cc983a4045313e1ec7075c5a5b84f6212b097d36a1b'
+        );
+    });
+
+    it('matches the reference signature on Amoy testnet (V2 exchange)', function (): void {
+        $signer = new Eip712Signer(GOLDEN_V2_KEY, 80002);
+
+        $signature = $signer->sign(new OrderPayloadV2(goldenOrderDataV2(), 80002));
+
+        expect($signature)->toBe(
+            '0xa96be879ff1c5b94c1f7bbb4e253e2283748c1261f8b21390979d31ee6a16465'
+            . '6132219cf49fd86574380b4f5f11232945497b29ffbc74d4bf9a0623c17af0071b'
+        );
+    });
+
+    it('matches the reference signature for a neg-risk order on mainnet', function (): void {
+        $signer = new Eip712Signer(GOLDEN_V2_KEY, 137);
+
+        $signature = $signer->sign(new OrderPayloadV2(goldenOrderDataV2(), 137, negRisk: true));
+
+        expect($signature)->toBe(
+            '0x0cf7ad04271cdfe92e93422d1ea1154b0c297b101f08c030f4b7555d7e63419e'
+            . '5372c7b3ba494ebf1a54e9df77b1137b1f3ee76017e4c5bb0cdc8073885e194a1c'
+        );
+    });
+
+    it('matches the reference signature for a version 3 order on mainnet', function (): void {
+        $signer = new Eip712Signer(GOLDEN_V2_KEY, 137);
+
+        $signature = $signer->sign(new OrderPayloadV2(goldenOrderDataV2(), 137, version: 3));
+
+        expect($signature)->toBe(
+            '0x1406e9ec3bcaf3101971b2b612b5680c222e61df601ccc9a9f1f37144f10f49f'
+            . '408bbed7b390357803b2d1b6562a604335b790582211e76401ddbe6ae2ebc0dd1c'
+        );
+    });
+});

--- a/tests/Unit/Signing/TypedData/ClobAuthPayloadTest.php
+++ b/tests/Unit/Signing/TypedData/ClobAuthPayloadTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use PolymarketPhp\Polymarket\Signing\TypedData\ClobAuthPayload;
+
+describe('ClobAuthPayload::getPrimaryType()', function (): void {
+    it('returns ClobAuth', function (): void {
+        $payload = new ClobAuthPayload('0xAddress', 1_234_567_890);
+
+        expect($payload->getPrimaryType())->toBe('ClobAuth');
+    });
+});
+
+describe('ClobAuthPayload::getDomain()', function (): void {
+    it('builds the correct domain structure', function (): void {
+        $payload = new ClobAuthPayload('0xAddress', 1_234_567_890, 0, 137);
+
+        expect($payload->getDomain())->toBe([
+            'name'    => 'ClobAuthDomain',
+            'version' => '1',
+            'chainId' => 137,
+        ]);
+    });
+
+    it('embeds the provided chain ID in the domain', function (): void {
+        $payload = new ClobAuthPayload('0xAddress', 1_234_567_890, 0, 80002);
+
+        expect($payload->getDomain()['chainId'])->toBe(80002);
+    });
+
+    it('defaults chain ID to 137 (Polygon mainnet)', function (): void {
+        $payload = new ClobAuthPayload('0xAddress', 1_234_567_890);
+
+        expect($payload->getDomain()['chainId'])->toBe(137);
+    });
+});
+
+describe('ClobAuthPayload::getDomainTypes()', function (): void {
+    it('contains name, version, and chainId fields', function (): void {
+        $payload = new ClobAuthPayload('0xAddress', 1_234_567_890);
+
+        $names = array_column($payload->getDomainTypes(), 'name');
+
+        expect($names)->toBe(['name', 'version', 'chainId']);
+    });
+});
+
+describe('ClobAuthPayload::getTypes()', function (): void {
+    it('contains ClobAuth key with four fields', function (): void {
+        $payload = new ClobAuthPayload('0xAddress', 1_234_567_890);
+        $types = $payload->getTypes();
+
+        expect($types)->toHaveKey('ClobAuth')
+            ->and($types['ClobAuth'])->toHaveCount(4);
+    });
+
+    it('defines the correct field names and EIP-712 types', function (): void {
+        $payload = new ClobAuthPayload('0xAddress', 1_234_567_890);
+        $fields = $payload->getTypes()['ClobAuth'];
+
+        expect($fields)->toBe([
+            ['name' => 'address',   'type' => 'address'],
+            ['name' => 'timestamp', 'type' => 'string'],
+            ['name' => 'nonce',     'type' => 'uint256'],
+            ['name' => 'message',   'type' => 'string'],
+        ]);
+    });
+});
+
+describe('ClobAuthPayload::getMessage()', function (): void {
+    it('lowercases the wallet address', function (): void {
+        $payload = new ClobAuthPayload('0xABCDEF1234567890ABCDEF1234567890ABCDEF12', 1_234_567_890);
+
+        expect($payload->getMessage()['address'])
+            ->toBe('0xabcdef1234567890abcdef1234567890abcdef12');
+    });
+
+    it('converts the timestamp to a string', function (): void {
+        $payload = new ClobAuthPayload('0xAddress', 1_234_567_890);
+
+        expect($payload->getMessage()['timestamp'])
+            ->toBe('1234567890')
+            ->toBeString();
+    });
+
+    it('keeps the nonce as an integer', function (): void {
+        $payload = new ClobAuthPayload('0xAddress', 1_234_567_890, 5);
+
+        expect($payload->getMessage()['nonce'])->toBe(5)->toBeInt();
+    });
+
+    it('defaults nonce to 0', function (): void {
+        $payload = new ClobAuthPayload('0xAddress', 1_234_567_890);
+
+        expect($payload->getMessage()['nonce'])->toBe(0);
+    });
+
+    it('includes the standard attestation message', function (): void {
+        $payload = new ClobAuthPayload('0xAddress', 1_234_567_890);
+
+        expect($payload->getMessage()['message'])
+            ->toBe('This message attests that I control the given wallet');
+    });
+});

--- a/tests/Unit/Signing/TypedData/OrderPayloadTest.php
+++ b/tests/Unit/Signing/TypedData/OrderPayloadTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+use PolymarketPhp\Polymarket\Signing\TypedData\OrderPayload;
+
+/**
+ * Minimal order data covering all 12 EIP-712 Order struct fields.
+ *
+ * @return array<string, mixed>
+ */
+function sampleOrderData(): array
+{
+    return [
+        'salt'          => 12_345,
+        'maker'         => '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+        'signer'        => '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+        'taker'         => '0x0000000000000000000000000000000000000000',
+        'tokenId'       => '71321045679252212594626385532706912750332728571942532289631379312455583992563',
+        'makerAmount'   => '100000',
+        'takerAmount'   => '100000',
+        'expiration'    => 0,
+        'nonce'         => 0,
+        'feeRateBps'    => 0,
+        'side'          => 0,
+        'signatureType' => 0,
+    ];
+}
+
+describe('OrderPayload::getPrimaryType()', function (): void {
+    it('returns Order', function (): void {
+        $payload = new OrderPayload(sampleOrderData());
+
+        expect($payload->getPrimaryType())->toBe('Order');
+    });
+});
+
+describe('OrderPayload::getDomain() – mainnet', function (): void {
+    it('uses the Polymarket CTF Exchange name and version 1', function (): void {
+        $payload = new OrderPayload(sampleOrderData());
+        $domain = $payload->getDomain();
+
+        expect($domain['name'])->toBe('Polymarket CTF Exchange')
+            ->and($domain['version'])->toBe('1');
+    });
+
+    it('defaults to mainnet chain ID and mainnet verifying contract', function (): void {
+        $payload = new OrderPayload(sampleOrderData());
+        $domain = $payload->getDomain();
+
+        expect($domain['chainId'])->toBe(OrderPayload::MAINNET_CHAIN_ID)
+            ->and($domain['verifyingContract'])->toBe(OrderPayload::CTF_EXCHANGE_MAINNET);
+    });
+});
+
+describe('OrderPayload::getDomain() – testnet', function (): void {
+    it('auto-selects the testnet contract when chain ID is 80002', function (): void {
+        $payload = new OrderPayload(sampleOrderData(), OrderPayload::TESTNET_CHAIN_ID);
+        $domain = $payload->getDomain();
+
+        expect($domain['chainId'])->toBe(OrderPayload::TESTNET_CHAIN_ID)
+            ->and($domain['verifyingContract'])->toBe(OrderPayload::CTF_EXCHANGE_TESTNET);
+    });
+
+    it('mainnet chain ID always selects the mainnet contract', function (): void {
+        $payload = new OrderPayload(sampleOrderData(), OrderPayload::MAINNET_CHAIN_ID);
+
+        expect($payload->getDomain()['verifyingContract'])->toBe(OrderPayload::CTF_EXCHANGE_MAINNET);
+    });
+});
+
+describe('OrderPayload – custom verifying contract', function (): void {
+    it('accepts an explicit verifying contract address overriding auto-selection', function (): void {
+        $custom = '0x1234567890AbcDef1234567890AbCdef12345678';
+        $payload = new OrderPayload(sampleOrderData(), OrderPayload::MAINNET_CHAIN_ID, $custom);
+
+        expect($payload->getDomain()['verifyingContract'])->toBe($custom);
+    });
+});
+
+describe('OrderPayload::getDomainTypes()', function (): void {
+    it('contains name, version, chainId, and verifyingContract', function (): void {
+        $payload = new OrderPayload(sampleOrderData());
+        $names = array_column($payload->getDomainTypes(), 'name');
+
+        expect($names)->toBe(['name', 'version', 'chainId', 'verifyingContract']);
+    });
+});
+
+describe('OrderPayload::getTypes()', function (): void {
+    it('exposes all 12 EIP-712 Order struct fields', function (): void {
+        $payload = new OrderPayload(sampleOrderData());
+        $fieldNames = array_column($payload->getTypes()['Order'], 'name');
+
+        expect($fieldNames)->toContain('salt')
+            ->and($fieldNames)->toContain('maker')
+            ->and($fieldNames)->toContain('signer')
+            ->and($fieldNames)->toContain('taker')
+            ->and($fieldNames)->toContain('tokenId')
+            ->and($fieldNames)->toContain('makerAmount')
+            ->and($fieldNames)->toContain('takerAmount')
+            ->and($fieldNames)->toContain('expiration')
+            ->and($fieldNames)->toContain('nonce')
+            ->and($fieldNames)->toContain('feeRateBps')
+            ->and($fieldNames)->toContain('side')
+            ->and($fieldNames)->toContain('signatureType');
+    });
+
+    it('types side as uint8 and signatureType as uint8', function (): void {
+        $payload = new OrderPayload(sampleOrderData());
+        $typesByName = array_column($payload->getTypes()['Order'], 'type', 'name');
+
+        expect($typesByName['side'])->toBe('uint8')
+            ->and($typesByName['signatureType'])->toBe('uint8');
+    });
+});
+
+describe('OrderPayload::getMessage()', function (): void {
+    it('returns the order data as-is', function (): void {
+        $data = sampleOrderData();
+        $payload = new OrderPayload($data);
+
+        expect($payload->getMessage())->toBe($data);
+    });
+});

--- a/tests/Unit/Signing/TypedData/OrderPayloadV2Test.php
+++ b/tests/Unit/Signing/TypedData/OrderPayloadV2Test.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+use PolymarketPhp\Polymarket\Signing\TypedData\OrderPayloadV2;
+
+/**
+ * Minimal order data covering all 11 V2 EIP-712 Order struct fields.
+ *
+ * @return array<string, mixed>
+ */
+function sampleOrderDataV2(): array
+{
+    return [
+        'salt'          => 479_249_096_354,
+        'maker'         => '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+        'signer'        => '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+        'tokenId'       => '1234',
+        'makerAmount'   => '100000000',
+        'takerAmount'   => '50000000',
+        'side'          => 0,
+        'signatureType' => 0,
+        'timestamp'     => '1780449126930',
+        'metadata'      => OrderPayloadV2::BYTES32_ZERO,
+        'builder'       => OrderPayloadV2::BYTES32_ZERO,
+    ];
+}
+
+describe('OrderPayloadV2::getPrimaryType()', function (): void {
+    it('returns Order', function (): void {
+        $payload = new OrderPayloadV2(sampleOrderDataV2());
+
+        expect($payload->getPrimaryType())->toBe('Order');
+    });
+});
+
+describe('OrderPayloadV2::getDomain() – version 2', function (): void {
+    it('uses the Polymarket CTF Exchange name and version 2', function (): void {
+        $payload = new OrderPayloadV2(sampleOrderDataV2());
+        $domain = $payload->getDomain();
+
+        expect($domain['name'])->toBe('Polymarket CTF Exchange')
+            ->and($domain['version'])->toBe('2');
+    });
+
+    it('defaults to mainnet chain ID and the V2 exchange contract', function (): void {
+        $payload = new OrderPayloadV2(sampleOrderDataV2());
+        $domain = $payload->getDomain();
+
+        expect($domain['chainId'])->toBe(OrderPayloadV2::MAINNET_CHAIN_ID)
+            ->and($domain['verifyingContract'])->toBe(OrderPayloadV2::CTF_EXCHANGE_V2);
+    });
+
+    it('selects the neg-risk V2 exchange when negRisk is true', function (): void {
+        $payload = new OrderPayloadV2(sampleOrderDataV2(), negRisk: true);
+
+        expect($payload->getDomain()['verifyingContract'])
+            ->toBe(OrderPayloadV2::NEG_RISK_CTF_EXCHANGE_V2);
+    });
+
+    it('uses the same V2 exchange contract on testnet', function (): void {
+        $payload = new OrderPayloadV2(sampleOrderDataV2(), OrderPayloadV2::TESTNET_CHAIN_ID);
+        $domain = $payload->getDomain();
+
+        expect($domain['chainId'])->toBe(OrderPayloadV2::TESTNET_CHAIN_ID)
+            ->and($domain['verifyingContract'])->toBe(OrderPayloadV2::CTF_EXCHANGE_V2);
+    });
+});
+
+describe('OrderPayloadV2::getDomain() – version 3', function (): void {
+    it('uses domain version 3 and the mainnet V3 exchange contract', function (): void {
+        $payload = new OrderPayloadV2(sampleOrderDataV2(), version: 3);
+        $domain = $payload->getDomain();
+
+        expect($domain['version'])->toBe('3')
+            ->and($domain['verifyingContract'])->toBe(OrderPayloadV2::CTF_EXCHANGE_V3_MAINNET);
+    });
+
+    it('selects the testnet V3 exchange contract on Amoy', function (): void {
+        $payload = new OrderPayloadV2(
+            sampleOrderDataV2(),
+            OrderPayloadV2::TESTNET_CHAIN_ID,
+            version: 3,
+        );
+
+        expect($payload->getDomain()['verifyingContract'])
+            ->toBe(OrderPayloadV2::CTF_EXCHANGE_V3_TESTNET);
+    });
+
+    it('ignores the negRisk flag on version 3 (single exchange contract)', function (): void {
+        $payload = new OrderPayloadV2(sampleOrderDataV2(), negRisk: true, version: 3);
+
+        expect($payload->getDomain()['verifyingContract'])
+            ->toBe(OrderPayloadV2::CTF_EXCHANGE_V3_MAINNET);
+    });
+});
+
+describe('OrderPayloadV2 – validation and overrides', function (): void {
+    it('rejects unsupported order versions', function (): void {
+        expect(fn (): OrderPayloadV2 => new OrderPayloadV2(sampleOrderDataV2(), version: 1))
+            ->toThrow(InvalidArgumentException::class, 'version');
+    });
+
+    it('accepts an explicit verifying contract address overriding auto-selection', function (): void {
+        $custom = '0x1234567890AbcDef1234567890AbCdef12345678';
+        $payload = new OrderPayloadV2(
+            sampleOrderDataV2(),
+            verifyingContract: $custom,
+        );
+
+        expect($payload->getDomain()['verifyingContract'])->toBe($custom);
+    });
+});
+
+describe('OrderPayloadV2::getTypes()', function (): void {
+    it('exposes exactly the 11 V2 Order struct fields in canonical order', function (): void {
+        $payload = new OrderPayloadV2(sampleOrderDataV2());
+        $fieldNames = array_column($payload->getTypes()['Order'], 'name');
+
+        expect($fieldNames)->toBe([
+            'salt',
+            'maker',
+            'signer',
+            'tokenId',
+            'makerAmount',
+            'takerAmount',
+            'side',
+            'signatureType',
+            'timestamp',
+            'metadata',
+            'builder',
+        ]);
+    });
+
+    it('does not contain the removed V1 fields', function (): void {
+        $payload = new OrderPayloadV2(sampleOrderDataV2());
+        $fieldNames = array_column($payload->getTypes()['Order'], 'name');
+
+        expect($fieldNames)->not->toContain('taker')
+            ->and($fieldNames)->not->toContain('expiration')
+            ->and($fieldNames)->not->toContain('nonce')
+            ->and($fieldNames)->not->toContain('feeRateBps');
+    });
+
+    it('types metadata and builder as bytes32, timestamp as uint256', function (): void {
+        $payload = new OrderPayloadV2(sampleOrderDataV2());
+        $typesByName = array_column($payload->getTypes()['Order'], 'type', 'name');
+
+        expect($typesByName['metadata'])->toBe('bytes32')
+            ->and($typesByName['builder'])->toBe('bytes32')
+            ->and($typesByName['timestamp'])->toBe('uint256');
+    });
+});
+
+describe('OrderPayloadV2::getMessage()', function (): void {
+    it('returns the order data as-is', function (): void {
+        $data = sampleOrderDataV2();
+        $payload = new OrderPayloadV2($data);
+
+        expect($payload->getMessage())->toBe($data);
+    });
+});


### PR DESCRIPTION
## Why

Polymarket cut production over to CLOB V2 on **2026-04-28** (see the [official changelog](https://docs.polymarket.com/changelog)): new Exchange contracts, a new 11-field EIP-712 order struct, domain version `"2"`, and no backward compatibility — V1-signed orders are rejected. This PR migrates the signing path so `Orders::post()` works on production again. It also supports the Exchange V3 domain already rolling out (same struct, domain version `"3"`, resolvable via `GET /version`).

All struct fields, domain values, and contract addresses were verified against the official [`py-clob-client-v2`](https://github.com/Polymarket/py-clob-client-v2) and [`clob-client-v2`](https://github.com/Polymarket/clob-client-v2) sources.

## What

- **`OrderPayloadV2`** — V2/V3 EIP-712 order struct (`timestamp`, `metadata`, `builder` added; `taker`/`expiration`/`nonce`/`feeRateBps` removed from the signed struct), domain version matching the order version, and contract auto-selection: V2 `0xE111…996B`, V2 neg-risk `0xe222…0F59`, V3 per chain. `OrderPayload` (V1) is kept but deprecated.
- **`Orders::post()`** — signs and sends the V2 wire format (`salt` as int, `side` as string, `expiration` JSON-only defaulting to `"0"`), with new `negRisk`, `version`, and `postOnly` options and official defaults (millisecond timestamp, zero-bytes32 `metadata`/`builder`, random salt).
- **`SignatureType`** — canonical values: `EOA=0`, `POLY_PROXY=1`, `POLY_GNOSIS_SAFE=2`, `POLY_1271=3`. `POLY_1271` signing (nested Solady `TypedDataSign` flow) is out of scope and throws a clear `SigningException`.
- **`Server::getVersion()`** — exposes `GET /version` so callers can resolve the active order version like the official client (defaults to 2). No hidden HTTP calls in `post()`.
- ClobAuth (L1) is untouched — it stays at domain version `"1"` per the official docs.

## Testing

Developed test-first. The key evidence is four **golden-signature tests**: reference signatures were generated with `eth-account` (the library the official Python SDK signs with) for the official test fixture, and our signer reproduces them **byte-for-byte** across V2 standard, V2 neg-risk, and V3 domains on Polygon and Amoy. Full suite: 282 tests / 656 assertions, PHPStan clean.

## Relationship to #27

This branch is based on #27 and includes its commits — it upgrades the V1 signing path introduced there to V2. Recommended order: merge #27 first, after which this PR reduces to the two migration commits (`cc4eae1` design spec, `5f9cf9c` implementation).

Design doc: `docs/superpowers/specs/2026-07-11-clob-v2-order-signing-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)